### PR TITLE
fix: Claude GitHub Action OAuth認証の修正

### DIFF
--- a/.github/workflows/claude-official.yml
+++ b/.github/workflows/claude-official.yml
@@ -1,0 +1,42 @@
+name: Claude Code Official
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: yusaku0324/claude-code-action@main
+        with:
+          use_oauth: 'true'
+          claude_access_token: ${{ secrets.ACCESSTOKEN }}
+          claude_refresh_token: ${{ secrets.REFRESHTOKEN }}
+          claude_expires_at: ${{ secrets.EXPIRESAT }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
@claude メンションが動作しない問題を修正します。

## 変更内容
- 新しいワークフローファイル  を追加
- OAuth認証用の正しいシークレット名を使用（ACCESSTOKEN, REFRESHTOKEN, EXPIRESAT）
- yusaku0324/claude-code-action@main を使用（OAuth対応版）

## テスト方法
1. このPRをマージ後、Issueやコメントで @claude を使用
2. GitHub Actions のログを確認して正常に動作することを確認

## 関連Issue
- #45