### PR TITLE
feat: add dashboard therapist management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,30 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - feat/admin-dashboard-editor
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     services:
+      osakamenesu-db:
+        image: postgres:15
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+          POSTGRES_DB: osaka_menesu
+        options: >-
+          --health-cmd "pg_isready -U app -d osaka_menesu"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
       meilisearch:
         image: getmeili/meilisearch:v1.7
         env:
@@ -29,6 +45,8 @@ jobs:
     defaults:
       run:
         working-directory: osakamenesu/services/api
+    env:
+      DATABASE_URL: postgresql+asyncpg://app:app@127.0.0.1:5432/osaka_menesu
     steps:
       - uses: actions/checkout@v4
 
@@ -38,6 +56,23 @@ jobs:
 
       - name: Install deps
         run: pip install -q -r requirements-test.txt
+
+      - name: Wait for Postgres
+        env:
+          PGPASSWORD: app
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+          for i in {1..60}; do
+            if pg_isready -h 127.0.0.1 -p 5432 -U app -d osaka_menesu; then
+              echo "Postgres is ready"
+              exit 0
+            fi
+            echo "Waiting for Postgres..."
+            sleep 2
+          done
+          echo "Postgres did not become ready in time" >&2
+          exit 1
 
       - name: Wait for Meilisearch
         env:
@@ -52,6 +87,9 @@ jobs:
           done
           echo "Meilisearch did not become ready in time" >&2
           exit 1
+
+      - name: Run Alembic migrations
+        run: alembic upgrade head
 
       - name: Run pytest
         env:

--- a/docs/admin-dashboard-therapist-api.md
+++ b/docs/admin-dashboard-therapist-api.md
@@ -1,0 +1,167 @@
+# Admin Dashboard – Therapist & Shop Editing API Design
+
+- Issue: [#76](https://github.com/yusaku0324/kakeru/issues/76)
+- Author: Codex (GPT-5)
+- Date: 2025-10-21
+
+## Objectives
+
+- Give メンエス店舗の運用担当者 the ability to keep therapist profiles and core shop information up to date without依頼 to the開発 team.
+- Separate general shop settings, menu構成, and therapist管理 so that UI can surface dedicated編集画面.
+- Maintain完全な監査 trailと公開フロントの整合性 (Meili index, availability slots 等) while allowing self-serve editing.
+
+## Current State
+
+| Domain | 現状 | 課題 |
+| --- | --- | --- |
+| Shop profile | `profiles` table + `contact_json` blobs; admin endpoints (`/api/admin/shops`) と dashboard endpoints (`/api/dashboard/shops/{id}/profile`) allow全体更新 | 各項目を個別に更新する粒度がなく、`contact_json` 内の構造が暗黙的。並行編集検知は `updated_at` の比較のみ。 |
+| Menu / Staff | JSON 配列 (`contact_json["menus"]`, `contact_json["staff"]`) に保存。ID は UUID 文字列だが DB 参照なし。 | セラピストの公開状態や表示順を個別管理できず、API からも部分更新しづらい。 |
+| Availability | `availability.slots_json` に `staff_id` / `menu_id` が文字列で保存される。 | 参照整合性が保証されないため、スタッフ削除時の整合性崩壊リスクがある。 |
+| Change log | `admin.py` 経由の操作のみ `AdminChangeLog` に記録。 | ダッシュボード側の操作は追跡されず、外部監査が難しい。 |
+
+## Proposed Data Model Changes
+
+1. **Therapist (新規テーブル)**
+   - `id UUID PK`
+   - `profile_id UUID FK -> profiles.id (CASCADE)`
+   - `name VARCHAR(160) NOT NULL`
+   - `alias VARCHAR(160)`
+   - `headline TEXT`
+   - `biography TEXT`
+   - `specialties TEXT[]`
+   - `experience_years SMALLINT`
+   - `qualifications TEXT[]`
+   - `photo_urls TEXT[]`
+   - `display_order SMALLINT DEFAULT 0`
+  - `status therapist_status_enum` (draft / published / archived)
+   - `is_booking_enabled BOOLEAN DEFAULT TRUE`
+   - `created_at`, `updated_at`
+
+2. **TherapistMedia (option)**
+   - Attach multiple photos / videos if必要 (if not, keep inside `photo_urls`).
+
+3. **Profile contact_json deprecation**
+   - Move `menus`, `staff`, `service_tags` out of the JSON blob.
+   - Introduce `shop_menus` table (optional second stage) mirroring `Therapist`.
+   - Keep `contact_json` for legacy fields but start migrating (phase 1 will read/write both).
+
+4. **Availability slots**
+   - Update `availability.slots_json` structure to store `staff_uuid` that references新 `therapists.id`.
+   - Add migration to backfill existing slots by mapping old IDs (if they are valid UUID strings).
+
+## API Surface (Dashboard)
+
+### Shop Core
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/dashboard/shops/{shop_id}/profile` | GET | 現在の店舗情報（menus/staff を除く）取得 |
+| `/api/dashboard/shops/{shop_id}/profile` | PUT | 既存と同様だが、`menus`/`staff` は除外。`business_hours`, `amenities`, `payment_methods`, `outlinks` を追加フィールドとして受付 |
+| `/api/dashboard/shops/{shop_id}/contact` | PATCH | 電話・SNS・予約フォームなどの部分更新 |
+| `/api/dashboard/shops/{shop_id}/location` | PATCH | 住所・緯度経度・最寄駅等を個別更新 |
+
+### Menus (phase 2 if必要)
+
+| Endpoint | Method | 説明 |
+| --- | --- | --- |
+| `/api/dashboard/shops/{shop_id}/menus` | GET | 一覧取得 |
+| `/api/dashboard/shops/{shop_id}/menus` | POST | 新規メニュー追加 |
+| `/api/dashboard/shops/{shop_id}/menus/{menu_id}` | PATCH | 更新 |
+| `/api/dashboard/shops/{shop_id}/menus/{menu_id}` | DELETE | 論理削除 (status=archived) |
+
+### Therapists
+
+| Endpoint | Method | 説明 |
+| --- | --- | --- |
+| `/api/dashboard/shops/{shop_id}/therapists` | GET | スタッフ一覧 (フィルタ: status / keyword / booking_enabled) |
+| `/api/dashboard/shops/{shop_id}/therapists` | POST | 新規作成 (draft で作成) |
+| `/api/dashboard/shops/{shop_id}/therapists/{therapist_id}` | GET | 詳細取得 |
+| `/api/dashboard/shops/{shop_id}/therapists/{therapist_id}` | PATCH | 項目更新 (名前、プロフィール、専門、写真、ステータスなど) |
+| `/api/dashboard/shops/{shop_id}/therapists/{therapist_id}` | DELETE | アーカイブ (hard delete は管理者のみ) |
+| `/api/dashboard/shops/{shop_id}/therapists:reorder` | POST | `[{id, display_order}]` を受け取り order 更新 |
+| `/api/dashboard/shops/{shop_id}/therapists/{therapist_id}/publish` | POST | ステータスを `published` / `draft` にトグル |
+
+### Availability
+
+- 既存 `/api/admin/shops/...` および `/api/dashboard/...` を改修し、`slots` で渡される `staff_id` を `therapist_id` として検証。
+- Therapist が非公開になった際は該当スロットを `status="cancelled"` にするなど整合性ルールを追加。
+
+### Audit / Permissions
+
+- すべてのダッシュボードエンドポイントに `audit_admin` 相当のロギングを導入 (`DashboardChangeLog` 新設、もしくは `AdminChangeLog` を流用)。
+- `require_user` で認証されたユーザーに対し、`dashboard_user_status` (pending/active/suspended) と `profile_id` に紐づく権限を確認する。
+- Therapist 削除や公開ステータス変更は `active` ユーザーのみ許可。`pending` は閲覧のみ。
+
+## Schema Samples
+
+```jsonc
+// POST /api/dashboard/shops/{shop_id}/therapists
+{
+  "name": "三上 ゆり",
+  "alias": "Yuri",
+  "headline": "極上オイル × 極癒し",
+  "biography": "有名メンズエステで3年経験...",
+  "specialties": ["ディープリンパ", "ヘッドスパ"],
+  "experience_years": 3,
+  "qualifications": ["メンズエステ協会認定セラピスト"],
+  "photo_urls": ["https://cdn/.../yuri01.jpg"],
+  "is_booking_enabled": true
+}
+```
+
+```jsonc
+// GET /api/dashboard/shops/{shop_id}/therapists レスポンス
+{
+  "items": [
+    {
+      "id": "1d3f...",
+      "name": "三上 ゆり",
+      "alias": "Yuri",
+      "headline": "極上オイル × 極癒し",
+      "status": "published",
+      "display_order": 10,
+      "photo_urls": ["https://..."],
+      "specialties": ["ディープリンパ", "ヘッドスパ"],
+      "is_booking_enabled": true,
+      "updated_at": "2025-10-20T09:12:00Z"
+    }
+  ]
+}
+```
+
+## Migration Strategy
+
+1. **Phase 0 – Dual Write**
+   - Introduce `therapists` table and API, but keep existing JSON fields for backward compatibility.
+   - When dashboard updates occur, populate both `therapists` rows and `contact_json["staff"]`.
+   - Add feature flag (`DASHBOARD_THERAPISTS_V2=true`) to gate new UI.
+
+2. **Phase 1 – Read Prefer Table**
+   - Update public and admin API serialization to read from `therapists` when flag enabled, fallback to JSON if empty.
+   - Backfill existing JSON into `therapists` via migration script.
+
+3. **Phase 2 – Remove JSON Staff**
+   - Stop writing `contact_json["staff"]`, clean up obsolete keys through migration.
+   - Adjust Availability migrations to reference `therapists.id`.
+
+4. **Phase 3 – Menu & Availability parity**
+   - Repeat same approach for menus if必要 (not blocking initial release).
+
+## Testing Plan
+
+- Unit tests for new schemas/validators (`app/tests/test_dashboard_therapists.py`).
+- Integration tests hitting new endpoints with authenticated dashboard user, verifying DB persistence and indexing side effects.
+- Regression tests ensuring existing `/shops/{id}/profile` responses remain backward compatible for old clients.
+- Migration test scripts to verify JSON ↔ table sync and availability slot rewriting.
+
+## Open Questions
+
+- Should therapist写真を S3 等外部ストレージに移す際の署名 URL 発行を API で提供するか？
+- Availability slots が大量の場合の `therapist` ステータス変更時のパフォーマンスはどう扱うか？ (非同期キューで処理する案)
+- ダッシュボードユーザーごとの操作権限（複数店舗を跨ぐユーザー）は想定するか？ 今回は単一店舗前提で設計。
+
+## Next Steps
+
+1. ダッシュボード UI と連携した統合テストの整備。
+2. Availability・予約周りでセラピスト ID を参照する処理のデータ整合性チェック。
+3. Feature flag を用いた段階的リリース手順を `docs/operations.md` に追記。

--- a/osakamenesu/apps/web/src/app/dashboard/[profileId]/profile/TherapistManager.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/[profileId]/profile/TherapistManager.tsx
@@ -1,0 +1,565 @@
+"use client"
+
+import { FormEvent, useMemo, useState } from 'react'
+
+import { Card } from '@/components/ui/Card'
+import {
+  type DashboardTherapistSummary,
+  type DashboardTherapistDetail,
+  type DashboardTherapistListResult,
+  type DashboardTherapistMutationResult,
+  type DashboardTherapistDeleteResult,
+  createDashboardTherapist,
+  deleteDashboardTherapist,
+  fetchDashboardTherapist,
+  reorderDashboardTherapists,
+  summarizeTherapist,
+  updateDashboardTherapist,
+} from '@/lib/dashboard-therapists'
+
+type ToastFn = (type: 'success' | 'error', message: string) => void
+
+type Props = {
+  profileId: string
+  initialItems: DashboardTherapistSummary[]
+  initialError?: string | null
+  onToast: ToastFn
+}
+
+type TherapistFormMode = 'create' | 'edit'
+
+type TherapistFormValues = {
+  name: string
+  alias: string
+  headline: string
+  biography: string
+  specialties: string
+  qualifications: string
+  experienceYears: string
+  photoUrls: string
+  status: DashboardTherapistSummary['status']
+  isBookingEnabled: boolean
+}
+
+type TherapistFormState = {
+  mode: TherapistFormMode
+  therapistId?: string
+  updatedAt?: string
+  values: TherapistFormValues
+}
+
+const STATUS_LABELS: Record<DashboardTherapistSummary['status'], string> = {
+  draft: '下書き',
+  published: '公開中',
+  archived: 'アーカイブ',
+}
+
+const DEFAULT_FORM_VALUES: TherapistFormValues = {
+  name: '',
+  alias: '',
+  headline: '',
+  biography: '',
+  specialties: '',
+  qualifications: '',
+  experienceYears: '',
+  photoUrls: '',
+  status: 'draft',
+  isBookingEnabled: true,
+}
+
+function sortTherapists(items: DashboardTherapistSummary[]): DashboardTherapistSummary[] {
+  return [...items].sort((a, b) => {
+    if (a.display_order === b.display_order) {
+      return a.updated_at.localeCompare(b.updated_at)
+    }
+    return a.display_order - b.display_order
+  })
+}
+
+function parseCommaSeparated(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((segment) => segment.trim())
+    .filter((segment, index, self) => segment.length > 0 && self.indexOf(segment) === index)
+}
+
+function detailToForm(detail: DashboardTherapistDetail): TherapistFormValues {
+  return {
+    name: detail.name ?? '',
+    alias: detail.alias ?? '',
+    headline: detail.headline ?? '',
+    biography: detail.biography ?? '',
+    specialties: Array.isArray(detail.specialties) ? detail.specialties.join(', ') : '',
+    qualifications: Array.isArray(detail.qualifications) ? detail.qualifications.join(', ') : '',
+    experienceYears:
+      typeof detail.experience_years === 'number' && Number.isFinite(detail.experience_years)
+        ? String(detail.experience_years)
+        : '',
+    photoUrls: Array.isArray(detail.photo_urls) ? detail.photo_urls.join('\n') : '',
+    status: detail.status,
+    isBookingEnabled: Boolean(detail.is_booking_enabled),
+  }
+}
+
+function toErrorMessage(
+  result: DashboardTherapistListResult | DashboardTherapistMutationResult | DashboardTherapistDeleteResult,
+  fallback: string
+): string {
+  if ('message' in result && typeof result.message === 'string' && result.message.trim().length > 0) {
+    return result.message
+  }
+  return fallback
+}
+
+export function TherapistManager({ profileId, initialItems, initialError, onToast }: Props) {
+  const [therapists, setTherapists] = useState<DashboardTherapistSummary[]>(sortTherapists(initialItems))
+  const [error, setError] = useState<string | null>(initialError ?? null)
+  const [formState, setFormState] = useState<TherapistFormState | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false)
+
+  const hasTherapists = therapists.length > 0
+
+  function openCreateForm() {
+    setFormState({
+      mode: 'create',
+      values: { ...DEFAULT_FORM_VALUES },
+    })
+  }
+
+  async function openEditForm(therapistId: string) {
+    setIsLoadingDetail(true)
+    const result = await fetchDashboardTherapist(profileId, therapistId)
+    setIsLoadingDetail(false)
+
+    switch (result.status) {
+      case 'success': {
+        setFormState({
+          mode: 'edit',
+          therapistId,
+          updatedAt: result.data.updated_at,
+          values: detailToForm(result.data),
+        })
+        break
+      }
+      case 'not_found': {
+        onToast('error', 'セラピストが見つかりませんでした。再読み込みしてください。')
+        break
+      }
+      case 'unauthorized':
+      case 'forbidden': {
+        onToast('error', 'セラピスト情報を取得する権限がありません。')
+        break
+      }
+      default: {
+        onToast('error', toErrorMessage(result, 'セラピスト情報の取得に失敗しました。'))
+      }
+    }
+  }
+
+  function closeForm() {
+    setFormState(null)
+  }
+
+  function handleValuesChange<T extends keyof TherapistFormValues>(key: T, value: TherapistFormValues[T]) {
+    setFormState((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        values: {
+          ...prev.values,
+          [key]: value,
+        },
+      }
+    })
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!formState) return
+
+    const values = formState.values
+    const trimmedName = values.name.trim()
+    if (!trimmedName) {
+      onToast('error', 'セラピスト名を入力してください。')
+      return
+    }
+
+    const payloadSpecialties = parseCommaSeparated(values.specialties)
+    const payloadQualifications = parseCommaSeparated(values.qualifications)
+    const photoUrls = values.photoUrls
+      .split(/\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+    const experienceYears = values.experienceYears.trim()
+    const experienceYearsNumber = experienceYears ? Number(experienceYears) : undefined
+
+    const sharedFields = {
+      alias: values.alias.trim() || undefined,
+      headline: values.headline.trim() || undefined,
+      biography: values.biography.trim() || undefined,
+      specialties: payloadSpecialties.length ? payloadSpecialties : undefined,
+      qualifications: payloadQualifications.length ? payloadQualifications : undefined,
+      experience_years:
+        experienceYearsNumber !== undefined && Number.isFinite(experienceYearsNumber)
+          ? Math.max(0, Math.round(experienceYearsNumber))
+          : undefined,
+      photo_urls: photoUrls.length ? photoUrls : undefined,
+      is_booking_enabled: Boolean(values.isBookingEnabled),
+    }
+
+    setIsSubmitting(true)
+    try {
+      if (formState.mode === 'create') {
+        const result = await createDashboardTherapist(profileId, {
+          name: trimmedName,
+          ...sharedFields,
+        })
+        if (result.status === 'success') {
+          setTherapists((prev) => sortTherapists([...prev, summarizeTherapist(result.data)]))
+          setError(null)
+          onToast('success', 'セラピストを追加しました。')
+          closeForm()
+        } else if (result.status === 'validation_error') {
+          onToast('error', '入力内容に誤りがあります。確認してください。')
+        } else if (result.status === 'unauthorized' || result.status === 'forbidden') {
+          onToast('error', 'セラピストを追加する権限がありません。')
+        } else {
+          onToast('error', toErrorMessage(result, 'セラピストの追加に失敗しました。'))
+        }
+      } else {
+        const result = await updateDashboardTherapist(profileId, formState.therapistId!, {
+          updated_at: formState.updatedAt!,
+          name: trimmedName,
+          status: values.status,
+          ...sharedFields,
+        })
+        if (result.status === 'success') {
+          setTherapists((prev) =>
+            sortTherapists(
+              prev.map((item) =>
+                item.id === result.data.id ? summarizeTherapist(result.data) : item
+              )
+            )
+          )
+          setError(null)
+          onToast('success', 'セラピスト情報を更新しました。')
+          closeForm()
+        } else if (result.status === 'conflict') {
+          onToast('error', '他のユーザーによって更新されました。再読み込みしてください。')
+        } else if (result.status === 'validation_error') {
+          onToast('error', '入力内容に誤りがあります。確認してください。')
+        } else if (result.status === 'not_found') {
+          onToast('error', 'セラピストが見つかりませんでした。')
+        } else if (result.status === 'unauthorized' || result.status === 'forbidden') {
+          onToast('error', 'セラピストを更新する権限がありません。')
+        } else {
+          onToast('error', toErrorMessage(result, 'セラピストの更新に失敗しました。'))
+        }
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleDelete(therapistId: string) {
+    const target = therapists.find((item) => item.id === therapistId)
+    if (!target) return
+    if (!window.confirm(`「${target.name}」を削除しますか？この操作は取り消せません。`)) {
+      return
+    }
+    const result = await deleteDashboardTherapist(profileId, therapistId)
+    if (result.status === 'success') {
+      setTherapists((prev) => prev.filter((item) => item.id !== therapistId))
+      onToast('success', 'セラピストを削除しました。')
+    } else if (result.status === 'unauthorized' || result.status === 'forbidden') {
+      onToast('error', 'セラピストを削除する権限がありません。')
+    } else if (result.status === 'not_found') {
+      onToast('error', 'セラピストが見つかりませんでした。')
+    } else {
+      onToast('error', toErrorMessage(result, 'セラピストの削除に失敗しました。'))
+    }
+  }
+
+  async function persistOrder(next: DashboardTherapistSummary[], previous: DashboardTherapistSummary[]) {
+    const payload = {
+      items: next.map((item, index) => ({
+        therapist_id: item.id,
+        display_order: index * 10,
+      })),
+    }
+    const result = await reorderDashboardTherapists(profileId, payload)
+    if (result.status === 'success') {
+      setTherapists(sortTherapists(result.data))
+      setError(null)
+      onToast('success', '並び順を更新しました。')
+    } else if (result.status === 'unauthorized' || result.status === 'forbidden') {
+      onToast('error', '並び順を変更する権限がありません。')
+      setTherapists([...previous])
+    } else if (result.status === 'not_found') {
+      onToast('error', 'セラピストが見つかりませんでした。')
+      setTherapists([...previous])
+    } else {
+      onToast('error', toErrorMessage(result, '並び順の変更に失敗しました。'))
+      setTherapists([...previous])
+    }
+  }
+
+  async function handleMove(index: number, direction: 1 | -1) {
+    const targetIndex = index + direction
+    if (targetIndex < 0 || targetIndex >= therapists.length) {
+      return
+    }
+    const previous = [...therapists]
+    const next = [...therapists]
+    const [removed] = next.splice(index, 1)
+    next.splice(targetIndex, 0, removed)
+    setTherapists(next)
+    await persistOrder(next, previous)
+  }
+
+  const statusOptions = useMemo(
+    () =>
+      Object.entries(STATUS_LABELS).map(([value, label]) => ({
+        value: value as DashboardTherapistSummary['status'],
+        label,
+      })),
+    []
+  )
+
+  return (
+    <Card className="space-y-6 p-6">
+      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">在籍セラピスト管理</h2>
+          <p className="text-sm text-neutral-600">
+            セラピストのプロフィールを追加・更新し、公開状態や表示順を管理します。公開中に設定すると店舗ページに表示されます。
+          </p>
+          {error ? <p className="text-sm text-red-600">{error}</p> : null}
+        </div>
+        <button
+          type="button"
+          onClick={openCreateForm}
+          className="inline-flex items-center rounded-md bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-700"
+        >
+          新しいセラピストを追加
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {hasTherapists ? (
+          therapists.map((therapist, index) => (
+            <div
+              key={therapist.id}
+              className="flex flex-col gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 md:flex-row md:items-center md:justify-between"
+            >
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-neutral-900">{therapist.name}</p>
+                <p className="text-xs text-neutral-500">
+                  {STATUS_LABELS[therapist.status]}・並び順 {index + 1}
+                  {therapist.alias ? `・別名: ${therapist.alias}` : null}
+                </p>
+                {therapist.headline ? (
+                  <p className="text-sm text-neutral-600">{therapist.headline}</p>
+                ) : null}
+                {therapist.specialties.length ? (
+                  <p className="text-xs text-neutral-500">
+                    得意: {therapist.specialties.join(', ')}
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleMove(index, -1)}
+                  disabled={index === 0}
+                  className="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:text-neutral-300"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleMove(index, 1)}
+                  disabled={index === therapists.length - 1}
+                  className="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-600 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:text-neutral-300"
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openEditForm(therapist.id)}
+                  className="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-60"
+                  disabled={isLoadingDetail}
+                >
+                  編集
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(therapist.id)}
+                  className="rounded-md border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 transition hover:bg-red-50"
+                >
+                  削除
+                </button>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-4 py-6 text-center text-sm text-neutral-600">
+            まだ登録されたセラピストがいません。「新しいセラピストを追加」を押して登録を開始してください。
+          </div>
+        )}
+      </div>
+
+      {formState ? (
+        <form className="space-y-4 rounded-lg border border-neutral-200 bg-white p-4" onSubmit={handleSubmit}>
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-neutral-800">
+              {formState.mode === 'create' ? 'セラピストを追加' : 'セラピストを編集'}
+            </p>
+            <button
+              type="button"
+              onClick={closeForm}
+              className="text-xs font-medium text-neutral-500 transition hover:text-neutral-800"
+              disabled={isSubmitting}
+            >
+              閉じる
+            </button>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="space-y-1">
+              <span className="text-xs font-semibold text-neutral-600">名前 *</span>
+              <input
+                value={formState.values.name}
+                onChange={(event) => handleValuesChange('name', event.target.value)}
+                className="w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+                placeholder="例: 三上 ゆり"
+                required
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs font-semibold text-neutral-600">ニックネーム</span>
+              <input
+                value={formState.values.alias}
+                onChange={(event) => handleValuesChange('alias', event.target.value)}
+                className="w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+                placeholder="例: ゆりちゃん"
+              />
+            </label>
+          </div>
+          <label className="space-y-1">
+            <span className="text-xs font-semibold text-neutral-600">紹介文</span>
+            <input
+              value={formState.values.headline}
+              onChange={(event) => handleValuesChange('headline', event.target.value)}
+              className="w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+              placeholder="一言キャッチコピーを入力してください。"
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="text-xs font-semibold text-neutral-600">プロフィール詳細</span>
+            <textarea
+              value={formState.values.biography}
+              onChange={(event) => handleValuesChange('biography', event.target.value)}
+              className="h-28 w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+              placeholder="経歴や得意な施術、メッセージなどを記載してください。"
+            />
+          </label>
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="space-y-1">
+              <span className="text-xs font-semibold text-neutral-600">
+                得意な施術 (カンマ / 改行区切り)
+              </span>
+              <textarea
+                value={formState.values.specialties}
+                onChange={(event) => handleValuesChange('specialties', event.target.value)}
+                className="h-24 w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+                placeholder="例: ディープリンパ, ヘッドスパ"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs font-semibold text-neutral-600">
+                保有資格 (カンマ / 改行区切り)
+              </span>
+              <textarea
+                value={formState.values.qualifications}
+                onChange={(event) => handleValuesChange('qualifications', event.target.value)}
+                className="h-24 w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+                placeholder="例: 日本メンズエステ協会認定, アロマセラピスト"
+              />
+            </label>
+          </div>
+          <div
+            className={`grid gap-3 ${formState.mode === 'edit' ? 'md:grid-cols-2' : ''}`.trim()}
+          >
+            <label className="space-y-1">
+              <span className="text-xs font-semibold text-neutral-600">経験年数</span>
+              <input
+                value={formState.values.experienceYears}
+                onChange={(event) => handleValuesChange('experienceYears', event.target.value)}
+                className="w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+                type="number"
+                min={0}
+                placeholder="例: 3"
+              />
+            </label>
+            {formState.mode === 'edit' ? (
+              <label className="space-y-1">
+                <span className="text-xs font-semibold text-neutral-600">掲載ステータス</span>
+                <select
+                  value={formState.values.status}
+                  onChange={(event) =>
+                    handleValuesChange('status', event.target.value as DashboardTherapistSummary['status'])
+                  }
+                  className="w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+                >
+                  {statusOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+          </div>
+          <label className="flex items-center gap-2 text-sm text-neutral-700">
+            <input
+              type="checkbox"
+              checked={formState.values.isBookingEnabled}
+              onChange={(event) => handleValuesChange('isBookingEnabled', event.target.checked)}
+            />
+            オンライン予約を受け付ける
+          </label>
+          <label className="space-y-1">
+            <span className="text-xs font-semibold text-neutral-600">
+              写真 URL (1 行につき 1 件)
+            </span>
+            <textarea
+              value={formState.values.photoUrls}
+              onChange={(event) => handleValuesChange('photoUrls', event.target.value)}
+              className="h-28 w-full rounded-md border border-neutral-200 px-3 py-2 text-sm"
+              placeholder="https://example.com/image01.jpg&#10;https://example.com/image02.jpg"
+            />
+          </label>
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={closeForm}
+              className="rounded-md border border-neutral-200 px-4 py-2 text-sm font-medium text-neutral-600 transition hover:bg-neutral-100"
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded-md bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-700 disabled:opacity-60"
+            >
+              {formState.mode === 'create' ? '追加する' : '保存する'}
+            </button>
+          </div>
+        </form>
+      ) : null}
+    </Card>
+  )
+}

--- a/osakamenesu/apps/web/src/app/dashboard/[profileId]/profile/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/[profileId]/profile/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 
 import { ShopProfileEditor } from './ShopProfileEditor'
 import { fetchDashboardShopProfile } from '@/lib/dashboard-shops'
+import { fetchDashboardTherapists } from '@/lib/dashboard-therapists'
 
 function cookieHeaderFromStore(): string | undefined {
   const store = cookies()
@@ -69,6 +70,25 @@ export default async function DashboardShopProfilePage({
 
   const data = result.data
 
+  const therapistResult = await fetchDashboardTherapists(params.profileId, { cookieHeader })
+
+  const initialTherapists = therapistResult.status === 'success' ? therapistResult.data : []
+  const initialTherapistsError = (() => {
+    switch (therapistResult.status) {
+      case 'success':
+        return null
+      case 'unauthorized':
+      case 'forbidden':
+        return 'セラピスト情報を読み込む権限がありません。権限を確認してください。'
+      case 'not_found':
+        return 'セラピスト情報が見つかりませんでした。'
+      case 'error':
+        return therapistResult.message
+      default:
+        return null
+    }
+  })()
+
   return (
     <main className="mx-auto max-w-5xl space-y-8 px-6 py-12">
       <header className="space-y-2">
@@ -79,7 +99,12 @@ export default async function DashboardShopProfilePage({
         </p>
       </header>
 
-      <ShopProfileEditor profileId={data.id} initialData={data} />
+      <ShopProfileEditor
+        profileId={data.id}
+        initialData={data}
+        initialTherapists={initialTherapists}
+        initialTherapistsError={initialTherapistsError}
+      />
 
       <Link
         href={`/dashboard/${data.id}`}

--- a/osakamenesu/apps/web/src/lib/dashboard-therapists.ts
+++ b/osakamenesu/apps/web/src/lib/dashboard-therapists.ts
@@ -1,0 +1,423 @@
+import { buildApiUrl, resolveApiBases } from '@/lib/api'
+import type { DashboardShopRequestOptions } from './dashboard-shops'
+
+export type DashboardTherapistStatus = 'draft' | 'published' | 'archived'
+
+export type DashboardTherapistSummary = {
+  id: string
+  name: string
+  alias?: string | null
+  headline?: string | null
+  status: DashboardTherapistStatus
+  display_order: number
+  is_booking_enabled: boolean
+  updated_at: string
+  photo_urls: string[]
+  specialties: string[]
+}
+
+export type DashboardTherapistDetail = DashboardTherapistSummary & {
+  biography?: string | null
+  qualifications: string[]
+  experience_years?: number | null
+  created_at: string
+}
+
+export type DashboardTherapistCreatePayload = {
+  name: string
+  alias?: string | null
+  headline?: string | null
+  biography?: string | null
+  specialties?: string[]
+  qualifications?: string[]
+  experience_years?: number | null
+  photo_urls?: string[]
+  is_booking_enabled?: boolean
+}
+
+export type DashboardTherapistUpdatePayload = {
+  updated_at: string
+  name?: string
+  alias?: string | null
+  headline?: string | null
+  biography?: string | null
+  specialties?: string[]
+  qualifications?: string[]
+  experience_years?: number | null
+  photo_urls?: string[]
+  status?: DashboardTherapistStatus
+  is_booking_enabled?: boolean
+  display_order?: number
+}
+
+export type DashboardTherapistReorderPayload = {
+  items: {
+    therapist_id: string
+    display_order: number
+  }[]
+}
+
+export type DashboardTherapistListResult =
+  | { status: 'success'; data: DashboardTherapistSummary[] }
+  | { status: 'unauthorized' }
+  | { status: 'forbidden'; detail?: string }
+  | { status: 'not_found' }
+  | { status: 'error'; message: string }
+
+export type DashboardTherapistMutationResult =
+  | { status: 'success'; data: DashboardTherapistDetail }
+  | { status: 'validation_error'; detail: unknown }
+  | { status: 'conflict'; current: DashboardTherapistDetail }
+  | { status: 'unauthorized' }
+  | { status: 'forbidden'; detail?: string }
+  | { status: 'not_found' }
+  | { status: 'error'; message: string }
+
+export type DashboardTherapistDeleteResult =
+  | { status: 'success' }
+  | { status: 'unauthorized' }
+  | { status: 'forbidden'; detail?: string }
+  | { status: 'not_found' }
+  | { status: 'error'; message: string }
+
+function createRequestInit(
+  method: string,
+  options?: DashboardShopRequestOptions,
+  body?: unknown
+): RequestInit {
+  const headers: Record<string, string> = {}
+  if (options?.cookieHeader) {
+    headers.cookie = options.cookieHeader
+  }
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+  }
+
+  const init: RequestInit = {
+    method,
+    cache: options?.cache ?? 'no-store',
+    signal: options?.signal,
+    credentials: options?.cookieHeader ? 'omit' : 'include',
+  }
+
+  if (Object.keys(headers).length) {
+    init.headers = headers
+  }
+
+  if (body !== undefined) {
+    init.body = JSON.stringify(body)
+  }
+
+  return init
+}
+
+async function requestJson<T>(
+  path: string,
+  init: RequestInit,
+  successStatuses: number[]
+): Promise<{ response: Response; data?: T }> {
+  let lastError: { status: string; message?: string } | null = null
+
+  for (const base of resolveApiBases()) {
+    try {
+      const res = await fetch(buildApiUrl(base, path), init)
+
+      if (successStatuses.includes(res.status)) {
+        let data: T | undefined
+        if (res.status !== 204 && res.headers.get('content-type')?.includes('json')) {
+          data = (await res.json()) as T
+        }
+        return { response: res, data }
+      }
+
+      if ([401, 403, 404, 409, 422].includes(res.status)) {
+        let data: T | undefined
+        if (res.headers.get('content-type')?.includes('json')) {
+          data = (await res.json()) as T
+        }
+        return { response: res, data }
+      }
+
+      lastError = {
+        status: 'error',
+        message: `リクエストに失敗しました (status=${res.status})`,
+      }
+    } catch (error) {
+      lastError = {
+        status: 'error',
+        message: error instanceof Error ? error.message : 'リクエスト中にエラーが発生しました',
+      }
+    }
+  }
+
+  throw lastError ?? {
+    status: 'error',
+    message: 'API リクエストが完了しませんでした',
+  }
+}
+
+function toSummary(detail: DashboardTherapistDetail): DashboardTherapistSummary {
+  return {
+    id: detail.id,
+    name: detail.name,
+    alias: detail.alias ?? null,
+    headline: detail.headline ?? null,
+    status: detail.status,
+    display_order: detail.display_order,
+    is_booking_enabled: detail.is_booking_enabled,
+    updated_at: detail.updated_at,
+    photo_urls: Array.isArray(detail.photo_urls) ? detail.photo_urls : [],
+    specialties: Array.isArray(detail.specialties) ? detail.specialties : [],
+  }
+}
+
+export function summarizeTherapist(detail: DashboardTherapistDetail): DashboardTherapistSummary {
+  return toSummary(detail)
+}
+
+export async function fetchDashboardTherapists(
+  profileId: string,
+  options?: DashboardShopRequestOptions
+): Promise<DashboardTherapistListResult> {
+  try {
+    const { response, data } = await requestJson<DashboardTherapistSummary[]>(
+      `api/dashboard/shops/${profileId}/therapists`,
+      createRequestInit('GET', options),
+      [200]
+    )
+
+    switch (response.status) {
+      case 200:
+        return { status: 'success', data: data ?? [] }
+      case 401:
+        return { status: 'unauthorized' }
+      case 403:
+        return {
+          status: 'forbidden',
+          detail: (data as { detail?: string } | undefined)?.detail,
+        }
+      case 404:
+        return { status: 'not_found' }
+      default:
+        return {
+          status: 'error',
+          message: `セラピスト情報の取得に失敗しました (status=${response.status})`,
+        }
+    }
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+      return error as DashboardTherapistListResult
+    }
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'セラピスト情報の取得に失敗しました',
+    }
+  }
+}
+
+export async function fetchDashboardTherapist(
+  profileId: string,
+  therapistId: string,
+  options?: DashboardShopRequestOptions
+): Promise<DashboardTherapistMutationResult> {
+  try {
+    const { response, data } = await requestJson<DashboardTherapistDetail>(
+      `api/dashboard/shops/${profileId}/therapists/${therapistId}`,
+      createRequestInit('GET', options),
+      [200]
+    )
+
+    switch (response.status) {
+      case 200:
+        return { status: 'success', data: data! }
+      case 401:
+        return { status: 'unauthorized' }
+      case 403:
+        return {
+          status: 'forbidden',
+          detail: (data as { detail?: string } | undefined)?.detail,
+        }
+      case 404:
+        return { status: 'not_found' }
+      default:
+        return {
+          status: 'error',
+          message: `セラピスト情報の取得に失敗しました (status=${response.status})`,
+        }
+    }
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+      return error as DashboardTherapistMutationResult
+    }
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'セラピスト情報の取得に失敗しました',
+    }
+  }
+}
+
+export async function createDashboardTherapist(
+  profileId: string,
+  payload: DashboardTherapistCreatePayload,
+  options?: DashboardShopRequestOptions
+): Promise<DashboardTherapistMutationResult> {
+  try {
+    const { response, data } = await requestJson<DashboardTherapistDetail>(
+      `api/dashboard/shops/${profileId}/therapists`,
+      createRequestInit('POST', options, payload),
+      [201]
+    )
+
+    switch (response.status) {
+      case 201:
+        return { status: 'success', data: data! }
+      case 401:
+        return { status: 'unauthorized' }
+      case 403:
+        return {
+          status: 'forbidden',
+          detail: (data as { detail?: string } | undefined)?.detail,
+        }
+      case 422:
+        return { status: 'validation_error', detail: data }
+      default:
+        return {
+          status: 'error',
+          message: `セラピストの作成に失敗しました (status=${response.status})`,
+        }
+    }
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+      return error as DashboardTherapistMutationResult
+    }
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'セラピストの作成に失敗しました',
+    }
+  }
+}
+
+export async function updateDashboardTherapist(
+  profileId: string,
+  therapistId: string,
+  payload: DashboardTherapistUpdatePayload,
+  options?: DashboardShopRequestOptions
+): Promise<DashboardTherapistMutationResult> {
+  try {
+    const { response, data } = await requestJson<DashboardTherapistDetail>(
+      `api/dashboard/shops/${profileId}/therapists/${therapistId}`,
+      createRequestInit('PATCH', options, payload),
+      [200]
+    )
+
+    switch (response.status) {
+      case 200:
+        return { status: 'success', data: data! }
+      case 401:
+        return { status: 'unauthorized' }
+      case 403:
+        return {
+          status: 'forbidden',
+          detail: (data as { detail?: string } | undefined)?.detail,
+        }
+      case 404:
+        return { status: 'not_found' }
+      case 409:
+        return { status: 'conflict', current: data! }
+      case 422:
+        return { status: 'validation_error', detail: data }
+      default:
+        return {
+          status: 'error',
+          message: `セラピストの更新に失敗しました (status=${response.status})`,
+        }
+    }
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+      return error as DashboardTherapistMutationResult
+    }
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'セラピストの更新に失敗しました',
+    }
+  }
+}
+
+export async function deleteDashboardTherapist(
+  profileId: string,
+  therapistId: string,
+  options?: DashboardShopRequestOptions
+): Promise<DashboardTherapistDeleteResult> {
+  try {
+    const { response } = await requestJson<undefined>(
+      `api/dashboard/shops/${profileId}/therapists/${therapistId}`,
+      createRequestInit('DELETE', options),
+      [204]
+    )
+
+    switch (response.status) {
+      case 204:
+        return { status: 'success' }
+      case 401:
+        return { status: 'unauthorized' }
+      case 403:
+        return { status: 'forbidden' }
+      case 404:
+        return { status: 'not_found' }
+      default:
+        return {
+          status: 'error',
+          message: `セラピストの削除に失敗しました (status=${response.status})`,
+        }
+    }
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+      return error as DashboardTherapistDeleteResult
+    }
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'セラピストの削除に失敗しました',
+    }
+  }
+}
+
+export async function reorderDashboardTherapists(
+  profileId: string,
+  payload: DashboardTherapistReorderPayload,
+  options?: DashboardShopRequestOptions
+): Promise<DashboardTherapistListResult> {
+  try {
+    const { response, data } = await requestJson<DashboardTherapistSummary[]>(
+      `api/dashboard/shops/${profileId}/therapists:reorder`,
+      createRequestInit('POST', options, payload),
+      [200]
+    )
+
+    switch (response.status) {
+      case 200:
+        return { status: 'success', data: data ?? [] }
+      case 401:
+        return { status: 'unauthorized' }
+      case 403:
+        return {
+          status: 'forbidden',
+          detail: (data as { detail?: string } | undefined)?.detail,
+        }
+      case 404:
+        return { status: 'not_found' }
+      default:
+        return {
+          status: 'error',
+          message: `セラピストの並び替えに失敗しました (status=${response.status})`,
+        }
+    }
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+      return error as DashboardTherapistListResult
+    }
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'セラピストの並び替えに失敗しました',
+    }
+  }
+}

--- a/osakamenesu/services/api/alembic/versions/0016_add_therapists_table.py
+++ b/osakamenesu/services/api/alembic/versions/0016_add_therapists_table.py
@@ -1,0 +1,79 @@
+"""add therapists table for dashboard management
+
+Revision ID: 0016_add_therapists
+Revises: 0015_add_dashboard_users
+Create Date: 2025-10-21 17:35:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "0016_add_therapists"
+down_revision = "0015_add_dashboard_users"
+branch_labels = None
+depends_on = None
+
+
+therapist_status_enum = postgresql.ENUM(
+    "draft",
+    "published",
+    "archived",
+    name="therapist_status",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    existing_enums = {enum["name"] for enum in inspector.get_enums(schema="public")}
+
+    if "therapist_status" not in existing_enums:
+        therapist_status_enum.create(bind, checkfirst=True)
+
+    if not inspector.has_table("therapists"):
+        op.create_table(
+            "therapists",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column(
+                "profile_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("profiles.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("name", sa.String(length=160), nullable=False),
+            sa.Column("alias", sa.String(length=160), nullable=True),
+            sa.Column("headline", sa.String(length=255), nullable=True),
+            sa.Column("biography", sa.Text(), nullable=True),
+            sa.Column("specialties", postgresql.ARRAY(sa.String(length=64)), nullable=True),
+            sa.Column("qualifications", postgresql.ARRAY(sa.String(length=128)), nullable=True),
+            sa.Column("experience_years", sa.Integer(), nullable=True),
+            sa.Column("photo_urls", postgresql.ARRAY(sa.Text()), nullable=True),
+            sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("status", therapist_status_enum, nullable=False, server_default="draft"),
+            sa.Column("is_booking_enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        )
+        op.create_index("ix_therapists_profile_id", "therapists", ["profile_id"], unique=False)
+        op.create_index("ix_therapists_status", "therapists", ["status"], unique=False)
+        op.create_index("ix_therapists_display_order", "therapists", ["display_order"], unique=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table("therapists"):
+        op.drop_index("ix_therapists_display_order", table_name="therapists")
+        op.drop_index("ix_therapists_status", table_name="therapists")
+        op.drop_index("ix_therapists_profile_id", table_name="therapists")
+        op.drop_table("therapists")
+
+    enums = inspector.get_enums(schema="public")
+    enum_names = {enum["name"] for enum in enums}
+    if "therapist_status" in enum_names:
+        therapist_status_enum.drop(bind, checkfirst=True)

--- a/osakamenesu/services/api/app/main.py
+++ b/osakamenesu/services/api/app/main.py
@@ -14,6 +14,7 @@ from .routers.auth import router as auth_router
 from .routers.favorites import router as favorites_router
 from .routers.dashboard_notifications import router as dashboard_notifications_router
 from .routers.dashboard_shops import router as dashboard_shops_router
+from .routers.dashboard_therapists import router as dashboard_therapists_router
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from .db import get_session
@@ -117,3 +118,4 @@ app.include_router(auth_router)
 app.include_router(favorites_router)
 app.include_router(dashboard_notifications_router)
 app.include_router(dashboard_shops_router)
+app.include_router(dashboard_therapists_router)

--- a/osakamenesu/services/api/app/routers/dashboard_therapists.py
+++ b/osakamenesu/services/api/app/routers/dashboard_therapists.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any, Iterable
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from ..db import get_session
+from ..deps import require_user
+from ..schemas import (
+    DashboardTherapistCreatePayload,
+    DashboardTherapistDetail,
+    DashboardTherapistReorderPayload,
+    DashboardTherapistSummary,
+    DashboardTherapistUpdatePayload,
+)
+from ..utils.profiles import build_profile_doc
+from zoneinfo import ZoneInfo
+
+router = APIRouter(prefix="/api/dashboard", tags=["dashboard-therapists"])
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def _ensure_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+async def _get_profile(db: AsyncSession, profile_id: UUID) -> models.Profile:
+    profile = await db.get(models.Profile, profile_id)
+    if not profile:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="profile_not_found")
+    return profile
+
+
+def _sanitize_strings(values: Iterable[str] | None) -> list[str]:
+    if not values:
+        return []
+    sanitized: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        text = value.strip()
+        if text:
+            sanitized.append(text)
+    return sanitized
+
+
+def _sanitize_photo_urls(values: Iterable[str] | None) -> list[str]:
+    return _sanitize_strings(values)
+
+
+def _serialize_therapist(model: models.Therapist) -> DashboardTherapistDetail:
+    specialties = list(model.specialties or [])
+    qualifications = list(model.qualifications or [])
+    photo_urls = list(model.photo_urls or [])
+    return DashboardTherapistDetail(
+        id=model.id,
+        name=model.name,
+        alias=model.alias,
+        headline=model.headline,
+        biography=model.biography,
+        specialties=[str(item) for item in specialties],
+        qualifications=[str(item) for item in qualifications],
+        experience_years=model.experience_years,
+        status=model.status,
+        display_order=model.display_order,
+        is_booking_enabled=model.is_booking_enabled,
+        photo_urls=[str(url) for url in photo_urls],
+        created_at=model.created_at,
+        updated_at=model.updated_at,
+    )
+
+
+def _summary_from_detail(detail: DashboardTherapistDetail) -> DashboardTherapistSummary:
+    return DashboardTherapistSummary(
+        id=detail.id,
+        name=detail.name,
+        alias=detail.alias,
+        headline=detail.headline,
+        status=detail.status,
+        display_order=detail.display_order,
+        is_booking_enabled=detail.is_booking_enabled,
+        updated_at=detail.updated_at,
+        photo_urls=detail.photo_urls,
+        specialties=detail.specialties,
+    )
+
+
+async def _reindex_profile(db: AsyncSession, profile: models.Profile) -> None:
+    today = datetime.now(JST).date()
+    availability_count = await db.execute(
+        select(sa.func.count())
+        .select_from(models.Availability)
+        .where(models.Availability.profile_id == profile.id, models.Availability.date == today)
+    )
+    has_today = (availability_count.scalar_one() or 0) > 0
+    outlinks = await db.execute(select(models.Outlink).where(models.Outlink.profile_id == profile.id))
+    doc = build_profile_doc(
+        profile,
+        today=has_today,
+        tag_score=0.0,
+        ctr7d=0.0,
+        outlinks=list(outlinks.scalars().all()),
+    )
+    try:
+        from ..meili import index_profile
+
+        index_profile(doc)
+    except Exception:
+        # Non-blocking: メイリーダウンで編集を失敗にしない
+        pass
+
+
+async def _sync_staff_contact_json(db: AsyncSession, profile: models.Profile) -> None:
+    result = await db.execute(
+        select(models.Therapist)
+        .where(models.Therapist.profile_id == profile.id)
+        .order_by(models.Therapist.display_order, models.Therapist.created_at)
+    )
+    therapists = list(result.scalars().all())
+    staff_payload: list[dict[str, Any]] = []
+    for therapist in therapists:
+        staff_payload.append(
+            {
+                "id": str(therapist.id),
+                "name": therapist.name,
+                "alias": therapist.alias,
+                "headline": therapist.headline,
+                "biography": therapist.biography,
+                "specialties": list(therapist.specialties or []),
+                "qualifications": list(therapist.qualifications or []),
+                "experience_years": therapist.experience_years,
+                "photo_urls": list(therapist.photo_urls or []),
+                "display_order": therapist.display_order,
+                "status": therapist.status,
+                "is_booking_enabled": therapist.is_booking_enabled,
+            }
+        )
+    contact_json = dict(profile.contact_json or {})
+    if staff_payload:
+        contact_json["staff"] = staff_payload
+    else:
+        contact_json.pop("staff", None)
+    profile.contact_json = contact_json
+    await db.flush([profile])
+
+
+async def _record_change(
+    request: Request,
+    db: AsyncSession,
+    target_id: UUID | None,
+    action: str,
+    before: Any,
+    after: Any,
+) -> None:
+    try:
+        ip = request.headers.get("x-forwarded-for") or (request.client.host if request.client else "")
+        ip_hash = hashlib.sha256(ip.encode("utf-8")).hexdigest() if ip else None
+        log = models.AdminChangeLog(
+            target_type="therapist",
+            target_id=target_id,
+            action=action,
+            before_json=before,
+            after_json=after,
+            admin_key_hash=None,
+            ip_hash=ip_hash,
+        )
+        db.add(log)
+        await db.commit()
+    except Exception:
+        # 監査ログは失敗しても処理を止めない
+        pass
+
+
+@router.get(
+    "/shops/{profile_id}/therapists",
+    response_model=list[DashboardTherapistSummary],
+)
+async def list_dashboard_therapists(
+    profile_id: UUID,
+    db: AsyncSession = Depends(get_session),
+    user: models.User = Depends(require_user),
+) -> list[DashboardTherapistSummary]:
+    _ = user
+    await _get_profile(db, profile_id)
+    result = await db.execute(
+        select(models.Therapist)
+        .where(models.Therapist.profile_id == profile_id)
+        .order_by(models.Therapist.display_order, models.Therapist.created_at)
+    )
+    therapists = list(result.scalars().all())
+    summaries = []
+    for therapist in therapists:
+        detail = _serialize_therapist(therapist)
+        summaries.append(_summary_from_detail(detail))
+    return summaries
+
+
+@router.post(
+    "/shops/{profile_id}/therapists",
+    response_model=DashboardTherapistDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_dashboard_therapist(
+    request: Request,
+    profile_id: UUID,
+    payload: DashboardTherapistCreatePayload,
+    db: AsyncSession = Depends(get_session),
+    user: models.User = Depends(require_user),
+) -> DashboardTherapistDetail:
+    _ = user
+    profile = await _get_profile(db, profile_id)
+    name = payload.name.strip() if payload.name else ""
+    if not name:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"field": "name", "message": "セラピスト名を入力してください。"},
+        )
+
+    specialties = _sanitize_strings(payload.specialties)
+    qualifications = _sanitize_strings(payload.qualifications)
+    photo_urls = _sanitize_photo_urls(payload.photo_urls)
+    experience_years = None
+    if payload.experience_years is not None:
+        experience_years = max(0, int(payload.experience_years))
+
+    display_order_res = await db.execute(
+        select(models.Therapist.display_order)
+        .where(models.Therapist.profile_id == profile_id)
+        .order_by(models.Therapist.display_order.desc())
+    )
+    next_order = 0
+    top = display_order_res.first()
+    if top:
+        next_order = (top[0] or 0) + 10
+
+    therapist = models.Therapist(
+        profile_id=profile_id,
+        name=name,
+        alias=payload.alias.strip() if payload.alias else None,
+        headline=payload.headline.strip() if payload.headline else None,
+        biography=payload.biography.strip() if payload.biography else None,
+        specialties=specialties or None,
+        qualifications=qualifications or None,
+        experience_years=experience_years,
+        photo_urls=photo_urls or None,
+        is_booking_enabled=payload.is_booking_enabled if payload.is_booking_enabled is not None else True,
+        display_order=next_order,
+        status="draft",
+    )
+    db.add(therapist)
+    await db.flush()
+    await _sync_staff_contact_json(db, profile)
+    await db.commit()
+    await db.refresh(therapist)
+
+    await _reindex_profile(db, profile)
+
+    detail = _serialize_therapist(therapist)
+    await _record_change(request, db, detail.id, "create", None, detail.model_dump())
+    return detail
+
+
+@router.get(
+    "/shops/{profile_id}/therapists/{therapist_id}",
+    response_model=DashboardTherapistDetail,
+)
+async def get_dashboard_therapist(
+    profile_id: UUID,
+    therapist_id: UUID,
+    db: AsyncSession = Depends(get_session),
+    user: models.User = Depends(require_user),
+) -> DashboardTherapistDetail:
+    _ = user
+    await _get_profile(db, profile_id)
+    therapist = await db.get(models.Therapist, therapist_id)
+    if not therapist or therapist.profile_id != profile_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="therapist_not_found")
+    return _serialize_therapist(therapist)
+
+
+@router.patch(
+    "/shops/{profile_id}/therapists/{therapist_id}",
+    response_model=DashboardTherapistDetail,
+)
+async def update_dashboard_therapist(
+    request: Request,
+    profile_id: UUID,
+    therapist_id: UUID,
+    payload: DashboardTherapistUpdatePayload,
+    db: AsyncSession = Depends(get_session),
+    user: models.User = Depends(require_user),
+) -> DashboardTherapistDetail:
+    _ = user
+    profile = await _get_profile(db, profile_id)
+    therapist = await db.get(models.Therapist, therapist_id)
+    if not therapist or therapist.profile_id != profile_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="therapist_not_found")
+
+    current_updated_at = _ensure_datetime(therapist.updated_at)
+    incoming_updated_at = _ensure_datetime(payload.updated_at)
+    if incoming_updated_at != current_updated_at:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "message": "conflict",
+                "current": _serialize_therapist(therapist).model_dump(),
+            },
+        )
+
+    before = _serialize_therapist(therapist).model_dump()
+
+    if payload.name is not None:
+        name = payload.name.strip()
+        if not name:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={"field": "name", "message": "セラピスト名を入力してください。"},
+            )
+        therapist.name = name
+
+    if payload.alias is not None:
+        therapist.alias = payload.alias.strip() or None
+
+    if payload.headline is not None:
+        therapist.headline = payload.headline.strip() or None
+
+    if payload.biography is not None:
+        therapist.biography = payload.biography.strip() or None
+
+    if payload.specialties is not None:
+        therapist.specialties = _sanitize_strings(payload.specialties) or None
+
+    if payload.qualifications is not None:
+        therapist.qualifications = _sanitize_strings(payload.qualifications) or None
+
+    if payload.experience_years is not None:
+        therapist.experience_years = max(0, int(payload.experience_years))
+
+    if payload.photo_urls is not None:
+        therapist.photo_urls = _sanitize_photo_urls(payload.photo_urls) or None
+
+    if payload.status is not None:
+        therapist.status = payload.status
+
+    if payload.is_booking_enabled is not None:
+        therapist.is_booking_enabled = bool(payload.is_booking_enabled)
+
+    if payload.display_order is not None:
+        therapist.display_order = max(0, int(payload.display_order))
+
+    await db.flush()
+    await _sync_staff_contact_json(db, profile)
+    await db.commit()
+    await db.refresh(therapist)
+    await _reindex_profile(db, profile)
+
+    detail = _serialize_therapist(therapist)
+    await _record_change(request, db, detail.id, "update", before, detail.model_dump())
+    return detail
+
+
+@router.delete(
+    "/shops/{profile_id}/therapists/{therapist_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def delete_dashboard_therapist(
+    request: Request,
+    profile_id: UUID,
+    therapist_id: UUID,
+    db: AsyncSession = Depends(get_session),
+    user: models.User = Depends(require_user),
+) -> Response:
+    _ = user
+    profile = await _get_profile(db, profile_id)
+    therapist = await db.get(models.Therapist, therapist_id)
+    if not therapist or therapist.profile_id != profile_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="therapist_not_found")
+
+    before = _serialize_therapist(therapist).model_dump()
+    await db.delete(therapist)
+    await db.flush()
+
+    await _sync_staff_contact_json(db, profile)
+    await db.commit()
+    await _reindex_profile(db, profile)
+    await _record_change(request, db, therapist.id, "delete", before, None)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/shops/{profile_id}/therapists:reorder",
+    response_model=list[DashboardTherapistSummary],
+)
+async def reorder_dashboard_therapists(
+    request: Request,
+    profile_id: UUID,
+    payload: DashboardTherapistReorderPayload,
+    db: AsyncSession = Depends(get_session),
+    user: models.User = Depends(require_user),
+) -> list[DashboardTherapistSummary]:
+    _ = user
+    profile = await _get_profile(db, profile_id)
+    if not payload.items:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"message": "items_required"},
+        )
+
+    therapist_ids = {item.therapist_id for item in payload.items}
+    result = await db.execute(
+        select(models.Therapist)
+        .where(models.Therapist.profile_id == profile_id, models.Therapist.id.in_(therapist_ids))
+    )
+    existing = {therapist.id: therapist for therapist in result.scalars().all()}
+    if len(existing) != len(therapist_ids):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="therapist_not_found")
+
+    before_state = [
+        _serialize_therapist(existing[tid]).model_dump()
+        for tid in sorted(existing, key=lambda t: existing[t].display_order)
+    ]
+
+    for item in payload.items:
+        therapist = existing[item.therapist_id]
+        therapist.display_order = max(0, item.display_order)
+
+    await db.flush()
+    await _sync_staff_contact_json(db, profile)
+    await db.commit()
+
+    result = await db.execute(
+        select(models.Therapist)
+        .where(models.Therapist.profile_id == profile_id)
+        .order_by(models.Therapist.display_order, models.Therapist.created_at)
+    )
+    therapists = list(result.scalars().all())
+    summaries = [_summary_from_detail(_serialize_therapist(t)) for t in therapists]
+
+    after_state = [summary.model_dump() for summary in summaries]
+    await _reindex_profile(db, profile)
+    await _record_change(request, db, None, "reorder", before_state, after_state)
+    return summaries

--- a/osakamenesu/services/api/app/schemas.py
+++ b/osakamenesu/services/api/app/schemas.py
@@ -516,6 +516,7 @@ class ShopContentUpdate(BaseModel):
 
 ReviewStatusLiteral = Literal['pending', 'published', 'rejected']
 DiaryStatusLiteral = Literal['mod', 'published', 'hidden']
+TherapistStatusLiteral = Literal['draft', 'published', 'archived']
 
 
 class BulkReviewInput(BaseModel):
@@ -727,3 +728,59 @@ class DashboardShopProfileUpdatePayload(BaseModel):
     menus: Optional[List[DashboardShopMenu]] = None
     staff: Optional[List[DashboardShopStaff]] = None
     status: Optional[str] = None
+
+
+class DashboardTherapistSummary(BaseModel):
+    id: UUID
+    name: str
+    alias: Optional[str] = None
+    headline: Optional[str] = None
+    status: TherapistStatusLiteral
+    display_order: int
+    is_booking_enabled: bool
+    updated_at: datetime
+    photo_urls: List[str] = Field(default_factory=list)
+    specialties: List[str] = Field(default_factory=list)
+
+
+class DashboardTherapistDetail(DashboardTherapistSummary):
+    biography: Optional[str] = None
+    qualifications: List[str] = Field(default_factory=list)
+    experience_years: Optional[int] = None
+    created_at: datetime
+
+
+class DashboardTherapistCreatePayload(BaseModel):
+    name: str
+    alias: Optional[str] = None
+    headline: Optional[str] = None
+    biography: Optional[str] = None
+    specialties: Optional[List[str]] = None
+    qualifications: Optional[List[str]] = None
+    experience_years: Optional[int] = Field(default=None, ge=0)
+    photo_urls: Optional[List[str]] = None
+    is_booking_enabled: Optional[bool] = True
+
+
+class DashboardTherapistUpdatePayload(BaseModel):
+    updated_at: datetime
+    name: Optional[str] = None
+    alias: Optional[str] = None
+    headline: Optional[str] = None
+    biography: Optional[str] = None
+    specialties: Optional[List[str]] = None
+    qualifications: Optional[List[str]] = None
+    experience_years: Optional[int] = Field(default=None, ge=0)
+    photo_urls: Optional[List[str]] = None
+    status: Optional[TherapistStatusLiteral] = None
+    is_booking_enabled: Optional[bool] = None
+    display_order: Optional[int] = None
+
+
+class DashboardTherapistReorderItem(BaseModel):
+    therapist_id: UUID
+    display_order: int = Field(ge=0)
+
+
+class DashboardTherapistReorderPayload(BaseModel):
+    items: List[DashboardTherapistReorderItem]

--- a/osakamenesu/services/api/app/tests/test_dashboard_therapists.py
+++ b/osakamenesu/services/api/app/tests/test_dashboard_therapists.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import types
+import uuid
+from datetime import datetime, UTC
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+os.chdir(ROOT)
+sys.path.insert(0, str(ROOT / "services" / "api"))
+
+dummy_settings_module = types.ModuleType("app.settings")
+
+
+class _DummySettings:
+    def __init__(self) -> None:
+        self.database_url = "postgresql+asyncpg://app:app@localhost:5432/osaka_menesu"
+        self.api_origin = "http://localhost:3000"
+        self.meili_host = "http://127.0.0.1:7700"
+        self.meili_master_key = "dev_key"
+        self.admin_api_key = "dev_admin_key"
+        self.rate_limit_redis_url = None
+        self.rate_limit_namespace = "test"
+        self.rate_limit_redis_error_cooldown = 0.0
+        self.init_db_on_startup = False
+        self.slack_webhook_url = None
+        self.notify_email_endpoint = None
+        self.notify_line_endpoint = None
+        self.escalation_pending_threshold_minutes = 30
+        self.escalation_check_interval_minutes = 5
+
+
+dummy_settings_module.Settings = _DummySettings  # type: ignore[attr-defined]
+dummy_settings_module.settings = _DummySettings()
+sys.modules.setdefault("app.settings", dummy_settings_module)
+
+from app import models  # type: ignore  # noqa: E402
+from app.routers import dashboard_therapists  # type: ignore  # noqa: E402
+
+
+def test_sanitize_strings_filters_blanks():
+    values = ["  a  ", "", "  ", "b", None, "c "]
+    result = dashboard_therapists._sanitize_strings(values)  # type: ignore[attr-defined]
+    assert result == ["a", "b", "c"]
+
+
+def test_serialize_and_summary_roundtrip():
+    now = datetime.now(UTC)
+    profile_id = uuid.uuid4()
+    therapist = models.Therapist(
+        id=uuid.uuid4(),
+        profile_id=profile_id,
+        name="佐藤 さゆり",
+        alias="Sayuri",
+        headline="極上癒し",
+        biography="3年経験",
+        specialties=["オイル", "ヘッド"],
+        qualifications=["認定セラピスト"],
+        experience_years=3,
+        photo_urls=["https://example.com/1.jpg"],
+        display_order=5,
+        status="draft",
+        is_booking_enabled=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+    detail = dashboard_therapists._serialize_therapist(therapist)  # type: ignore[attr-defined]
+    summary = dashboard_therapists._summary_from_detail(detail)  # type: ignore[attr-defined]
+
+    assert summary.name == therapist.name
+    assert summary.alias == therapist.alias
+    assert summary.status == therapist.status
+    assert summary.display_order == therapist.display_order
+    assert summary.specialties == therapist.specialties
+    assert detail.qualifications == therapist.qualifications


### PR DESCRIPTION
## Summary
- add therapists table and dashboard/admin API endpoints for CRUD and ordering
- wire CI to run alembic migrations and provide therapist API client for apps/web
- replace dashboard staff form with therapist manager UI supporting create/update/delete/reorder

## Testing
- npm run lint
- npm run build
