### PR TITLE
fix: allow dashboard shop creation

### DIFF
--- a/osakamenesu/apps/web/src/app/dashboard/new/ShopCreateForm.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/new/ShopCreateForm.tsx
@@ -5,11 +5,11 @@ import { useRouter } from 'next/navigation'
 
 import { ToastContainer, useToast } from '@/components/useToast'
 import { Badge } from '@/components/ui/Badge'
-import { createDashboardShopProfile, DashboardShopProfileCreatePayload, DashboardShopServiceType } from '@/lib/dashboard-shops'
-
-type Props = {
-  cookieHeader?: string
-}
+import {
+  createDashboardShopProfile,
+  type DashboardShopProfileCreatePayload,
+  type DashboardShopServiceType,
+} from '@/lib/dashboard-shops'
 
 const SERVICE_TYPE_OPTIONS: { label: string; value: DashboardShopServiceType }[] = [
   { label: '店舗型', value: 'store' },
@@ -30,7 +30,7 @@ function parseMultiline(input: string): string[] {
     .filter(Boolean)
 }
 
-export function ShopCreateForm({ cookieHeader }: Props) {
+export function ShopCreateForm() {
   const router = useRouter()
   const { toasts, push, remove } = useToast()
 
@@ -99,7 +99,7 @@ export function ShopCreateForm({ cookieHeader }: Props) {
 
     setIsSubmitting(true)
     try {
-      const result = await createDashboardShopProfile(payload, { cookieHeader })
+      const result = await createDashboardShopProfile(payload)
       switch (result.status) {
         case 'success': {
           push('success', '店舗を作成しました')

--- a/osakamenesu/apps/web/src/app/dashboard/new/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/new/page.tsx
@@ -1,24 +1,12 @@
 import Link from 'next/link'
-import { cookies } from 'next/headers'
 
 import { Card } from '@/components/ui/Card'
 import { ShopCreateForm } from './ShopCreateForm'
-
-function cookieHeaderFromStore(): string | undefined {
-  const store = cookies()
-  const entries = store.getAll()
-  if (!entries.length) {
-    return undefined
-  }
-  return entries.map((entry) => `${entry.name}=${entry.value}`).join('; ')
-}
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export default function DashboardNewShopPage() {
-  const cookieHeader = cookieHeaderFromStore()
-
   return (
     <main className="mx-auto max-w-4xl space-y-8 px-6 py-12">
       <header className="space-y-2">
@@ -29,7 +17,7 @@ export default function DashboardNewShopPage() {
       </header>
 
       <Card className="border-neutral-borderLight/80 bg-white/95 p-6 shadow-sm">
-        <ShopCreateForm cookieHeader={cookieHeader} />
+        <ShopCreateForm />
       </Card>
 
       <div>

--- a/osakamenesu/apps/web/src/lib/dashboard-shops.ts
+++ b/osakamenesu/apps/web/src/lib/dashboard-shops.ts
@@ -127,6 +127,7 @@ function createRequestInit(
     method,
     cache: options?.cache ?? 'no-store',
     signal: options?.signal,
+    credentials: options?.cookieHeader ? 'omit' : 'include',
   }
 
   if (Object.keys(headers).length) {


### PR DESCRIPTION
## Summary
- send credentials with dashboard shop API requests instead of manually setting Cookie header
- simplify new shop form to rely on browser-managed cookies

## Testing
- npm run lint
- npm run build