### PR TITLE
feat: add dashboard login flow

### DIFF
--- a/osakamenesu/apps/web/src/app/dashboard/[profileId]/notifications/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/[profileId]/notifications/page.tsx
@@ -29,11 +29,19 @@ export default async function DashboardNotificationsPage({
       <main className="mx-auto max-w-4xl space-y-6 px-6 py-12">
         <h1 className="text-2xl font-semibold">通知設定</h1>
         <p className="text-neutral-600">
-          通知設定を確認するにはログインが必要です。マジックリンクでログインした後、再読み込みしてください。
+          通知設定を確認するにはログインが必要です。ログインページからマジックリンクを送信し、メール経由でログインした後にこのページを再読み込みしてください。
         </p>
-        <Link href="/" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
-          トップへ戻る
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/dashboard/login" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
+            ログインページへ
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex rounded border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100"
+          >
+            トップへ戻る
+          </Link>
+        </div>
       </main>
     )
   }

--- a/osakamenesu/apps/web/src/app/dashboard/[profileId]/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/[profileId]/page.tsx
@@ -29,11 +29,19 @@ export default async function DashboardHomePage({
       <main className="mx-auto max-w-4xl space-y-6 px-6 py-12">
         <h1 className="text-2xl font-semibold">店舗ダッシュボード</h1>
         <p className="text-neutral-600">
-          ダッシュボードを表示するにはログインが必要です。マジックリンクでログインした後、このページを再読み込みしてください。
+          ダッシュボードを表示するにはログインが必要です。ログインページからマジックリンクを送信し、メール経由でログインした後にこのページを再読み込みしてください。
         </p>
-        <Link href="/" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
-          トップへ戻る
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/dashboard/login" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
+            ログインページへ
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex rounded border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100"
+          >
+            トップへ戻る
+          </Link>
+        </div>
       </main>
     )
   }

--- a/osakamenesu/apps/web/src/app/dashboard/[profileId]/profile/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/[profileId]/profile/page.tsx
@@ -30,11 +30,19 @@ export default async function DashboardShopProfilePage({
       <main className="mx-auto max-w-4xl space-y-6 px-6 py-12">
         <h1 className="text-2xl font-semibold">店舗プロフィール編集</h1>
         <p className="text-neutral-600">
-          店舗プロフィールを編集するにはログインが必要です。マジックリンクでログインした後、このページを再読み込みしてください。
+          店舗プロフィールを編集するにはログインが必要です。ログインページからマジックリンクを送信し、メール経由でログインした後にこのページを再読み込みしてください。
         </p>
-        <Link href="/" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
-          トップへ戻る
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/dashboard/login" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
+            ログインページへ
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex rounded border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100"
+          >
+            トップへ戻る
+          </Link>
+        </div>
       </main>
     )
   }

--- a/osakamenesu/apps/web/src/app/dashboard/favorites/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/favorites/page.tsx
@@ -123,11 +123,19 @@ export default async function FavoritesDashboardPage() {
       <main className="mx-auto max-w-4xl space-y-6 px-6 py-12">
         <h1 className="text-2xl font-semibold">お気に入り</h1>
         <p className="text-neutral-600">
-          お気に入りを表示するにはログインが必要です。マジックリンクでログインした後、このページを再読み込みしてください。
+          お気に入りを表示するにはログインが必要です。ログインページからマジックリンクを送信し、メール経由でログインした後にこのページを再読み込みしてください。
         </p>
-        <Link href="/" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
-          トップへ戻る
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/dashboard/login" className="inline-flex rounded bg-black px-4 py-2 text-sm font-medium text-white">
+            ログインページへ
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex rounded border border-neutral-300 px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-100"
+          >
+            トップへ戻る
+          </Link>
+        </div>
       </main>
     )
   }

--- a/osakamenesu/apps/web/src/app/dashboard/login/MagicLinkRequestForm.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/login/MagicLinkRequestForm.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { FormEvent, useState } from 'react'
+
+import { ToastContainer, useToast } from '@/components/useToast'
+import { requestDashboardMagicLink } from '@/lib/auth'
+
+type Status = 'idle' | 'sending' | 'success' | 'error'
+
+export function MagicLinkRequestForm() {
+  const { toasts, push, remove } = useToast()
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<Status>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const trimmed = email.trim()
+    if (!trimmed) {
+      setErrorMessage('メールアドレスを入力してください。')
+      return
+    }
+
+    setStatus('sending')
+    setErrorMessage(null)
+
+    const result = await requestDashboardMagicLink(trimmed)
+    switch (result.status) {
+      case 'success':
+        setStatus('success')
+        push('success', 'ログインリンクを送信しました。メールをご確認ください。')
+        break
+      case 'rate_limited':
+        setStatus('error')
+        setErrorMessage('短時間に複数回リクエストが行われました。しばらく時間をおいてから再度お試しください。')
+        break
+      case 'error':
+      default:
+        setStatus('error')
+        setErrorMessage(result.message)
+        break
+    }
+  }
+
+  const isSending = status === 'sending'
+
+  return (
+    <div className="space-y-6">
+      <ToastContainer toasts={toasts} onDismiss={remove} />
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="space-y-1">
+          <span className="text-sm font-medium text-neutral-text">メールアドレス</span>
+          <input
+            type="email"
+            inputMode="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="w-full rounded border border-neutral-borderLight px-3 py-2 text-sm"
+            placeholder="you@example.com"
+            required
+          />
+        </label>
+
+        {errorMessage ? (
+          <p className="text-sm text-state-dangerText">{errorMessage}</p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={isSending}
+          className="inline-flex items-center justify-center rounded-md bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSending ? '送信中...' : 'ログインリンクを送信'}
+        </button>
+      </form>
+
+      {status === 'success' ? (
+        <div className="rounded border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-700">
+          メールに記載されたリンクを同じブラウザで開くと自動的にログインが完了します。リンクの有効期限は数分間です。
+        </div>
+      ) : (
+        <p className="text-sm text-neutral-600">
+          ログインリンクは数分間有効です。届かない場合は迷惑メールフォルダもご確認ください。
+        </p>
+      )}
+    </div>
+  )
+}

--- a/osakamenesu/apps/web/src/app/dashboard/login/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/login/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+
+import { Card } from '@/components/ui/Card'
+import { MagicLinkRequestForm } from './MagicLinkRequestForm'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export default function DashboardLoginPage() {
+  return (
+    <main className="mx-auto max-w-lg space-y-8 px-6 py-12">
+      <header className="space-y-2 text-center">
+        <h1 className="text-3xl font-semibold tracking-tight">ダッシュボードにログイン</h1>
+        <p className="text-sm text-neutral-600">
+          登録済みのメールアドレスにマジックリンクを送信します。リンクを開くと自動的にログインが完了します。
+        </p>
+      </header>
+
+      <Card className="space-y-4 p-6">
+        <MagicLinkRequestForm />
+      </Card>
+
+      <div className="text-center text-sm text-neutral-600">
+        <p>リンクを開いた後はダッシュボードに戻り、店舗管理を開始できます。</p>
+        <p className="mt-2">
+          <Link href="/dashboard/favorites" className="text-brand-primary hover:underline">
+            お気に入り一覧を見る
+          </Link>
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/osakamenesu/apps/web/src/app/dashboard/new/ShopCreateForm.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/new/ShopCreateForm.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from 'next/link'
 import { FormEvent, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
@@ -10,6 +11,10 @@ import {
   type DashboardShopProfileCreatePayload,
   type DashboardShopServiceType,
 } from '@/lib/dashboard-shops'
+
+type Props = {
+  isAuthenticated: boolean
+}
 
 const SERVICE_TYPE_OPTIONS: { label: string; value: DashboardShopServiceType }[] = [
   { label: '店舗型', value: 'store' },
@@ -30,7 +35,7 @@ function parseMultiline(input: string): string[] {
     .filter(Boolean)
 }
 
-export function ShopCreateForm() {
+export function ShopCreateForm({ isAuthenticated }: Props) {
   const router = useRouter()
   const { toasts, push, remove } = useToast()
 
@@ -107,7 +112,7 @@ export function ShopCreateForm() {
           return
         }
         case 'unauthorized':
-          setFormError('ログインが必要です。マジックリンクで再度ログインしてください。')
+          setFormError('ログインが必要です。ログインページからマジックリンクを再送信してください。')
           break
         case 'forbidden':
           setFormError('店舗を作成する権限がありません。運営までお問い合わせください。')
@@ -124,6 +129,23 @@ export function ShopCreateForm() {
     } finally {
       setIsSubmitting(false)
     }
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="space-y-4">
+        <ToastContainer toasts={toasts} onDismiss={remove} />
+        <p className="text-sm text-neutral-600">
+          店舗を作成するにはログインが必要です。ログインページからマジックリンクを送信し、メール経由でログインした後にこのページを再読み込みしてください。
+        </p>
+        <Link
+          href="/dashboard/login"
+          className="inline-flex items-center justify-center rounded-md bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-700"
+        >
+          ログインページへ
+        </Link>
+      </div>
+    )
   }
 
   return (

--- a/osakamenesu/apps/web/src/app/dashboard/new/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/new/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cookies } from 'next/headers'
 
 import { Card } from '@/components/ui/Card'
 import { ShopCreateForm } from './ShopCreateForm'
@@ -7,6 +8,10 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export default function DashboardNewShopPage() {
+  const store = cookies()
+  const sessionCookie = store.get('osakamenesu_session')
+  const isAuthenticated = Boolean(sessionCookie?.value)
+
   return (
     <main className="mx-auto max-w-4xl space-y-8 px-6 py-12">
       <header className="space-y-2">
@@ -17,7 +22,7 @@ export default function DashboardNewShopPage() {
       </header>
 
       <Card className="border-neutral-borderLight/80 bg-white/95 p-6 shadow-sm">
-        <ShopCreateForm />
+        <ShopCreateForm isAuthenticated={isAuthenticated} />
       </Card>
 
       <div>

--- a/osakamenesu/apps/web/src/lib/auth.ts
+++ b/osakamenesu/apps/web/src/lib/auth.ts
@@ -1,0 +1,50 @@
+import { buildApiUrl, resolveApiBases } from '@/lib/api'
+
+export type MagicLinkRequestResult =
+  | { status: 'success' }
+  | { status: 'rate_limited' }
+  | { status: 'error'; message: string }
+
+export async function requestDashboardMagicLink(email: string): Promise<MagicLinkRequestResult> {
+  const payload = JSON.stringify({ email: email.trim() })
+  let lastError: string | null = null
+
+  for (const base of resolveApiBases()) {
+    try {
+      const response = await fetch(buildApiUrl(base, 'api/auth/request-link'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        cache: 'no-store',
+        body: payload,
+      })
+
+      if (response.status === 202) {
+        return { status: 'success' }
+      }
+
+      if (response.status === 429) {
+        return { status: 'rate_limited' }
+      }
+
+      const detail = await response
+        .json()
+        .then((data) => (data && (data.detail || data.message)) as string | undefined)
+        .catch(() => undefined)
+
+      lastError =
+        detail ??
+        `ログインリンクの送信に失敗しました (status=${response.status})`
+    } catch (error) {
+      lastError =
+        error instanceof Error ? error.message : 'ログインリンクの送信中にエラーが発生しました'
+    }
+  }
+
+  return {
+    status: 'error',
+    message: lastError ?? 'ログインリンクの送信に失敗しました。時間をおいて再度お試しください。',
+  }
+}


### PR DESCRIPTION
## Summary
- show login CTA when dashboard pages detect missing session cookie
- add /dashboard/login with magic-link request form hitting /api/auth/request-link
- guard shop creation form and related pages for unauthenticated users

## Testing
- npm run lint (osakamenesu/apps/web)
- pending: verify Cloud Run deploy + auth complete redirect