### PR TITLE
fix(api): restore resend tag names

### DIFF
--- a/osakamenesu/services/api/app/utils/email.py
+++ b/osakamenesu/services/api/app/utils/email.py
@@ -59,7 +59,13 @@ async def send_email_async(
     if text:
         payload["text"] = text
     if tags:
-        payload["tags"] = [{"name": tag} for tag in tags]
+        payload["tags"] = [
+            {
+                "name": tag,
+                "value": tag,
+            }
+            for tag in tags
+        ]
 
     headers = {
         "Authorization": f"Bearer {settings.mail_api_key}",


### PR DESCRIPTION
## Summary\n- ensure resend mail tags include both name and value while preserving caller-supplied tag strings\n\n## Testing\n- pytest app/tests/test_auth_magic_link.py