### PR TITLE
fix(auth): send dashboard logins to favorites

### DIFF
--- a/osakamenesu/apps/web/src/app/auth/complete/page.tsx
+++ b/osakamenesu/apps/web/src/app/auth/complete/page.tsx
@@ -50,7 +50,7 @@ function AuthCompleteContent() {
 
         const data = await res.json().catch(() => undefined)
         const scope = (data && typeof data.scope === 'string' ? data.scope : 'site') as 'dashboard' | 'site'
-        const redirectTarget = scope === 'dashboard' ? '/dashboard' : '/'
+        const redirectTarget = scope === 'dashboard' ? '/dashboard/favorites' : '/'
         const redirectLabel = scope === 'dashboard' ? 'ダッシュボード' : 'トップ'
 
         if (active) {


### PR DESCRIPTION
## Summary
- adjust auth completion redirect so dashboard sessions land directly on /dashboard/favorites

## Testing
- npm run lint