### PR TITLE
fix(auth): direct dashboard logins to editable profiles

### DIFF
--- a/osakamenesu/apps/web/src/app/auth/complete/page.tsx
+++ b/osakamenesu/apps/web/src/app/auth/complete/page.tsx
@@ -50,8 +50,36 @@ function AuthCompleteContent() {
 
         const data = await res.json().catch(() => undefined)
         const scope = (data && typeof data.scope === 'string' ? data.scope : 'site') as 'dashboard' | 'site'
-        const redirectTarget = scope === 'dashboard' ? '/dashboard/favorites' : '/'
-        const redirectLabel = scope === 'dashboard' ? 'ダッシュボード' : 'トップ'
+
+        let redirectTarget = '/'
+        let redirectLabel = 'トップ'
+
+        if (scope === 'dashboard') {
+          redirectLabel = 'ダッシュボード'
+          redirectTarget = '/dashboard'
+
+          try {
+            const listRes = await fetch('/api/dashboard/shops?limit=1', {
+              method: 'GET',
+              credentials: 'include',
+              cache: 'no-store',
+            })
+
+            if (listRes.ok) {
+              const listData = await listRes.json().catch(() => undefined) as { shops?: Array<{ id?: string }> } | undefined
+              const first = listData?.shops?.[0]
+              if (first?.id) {
+                redirectTarget = `/dashboard/${first.id}`
+              } else {
+                redirectTarget = '/dashboard/new'
+              }
+            } else if (listRes.status === 404) {
+              redirectTarget = '/dashboard/new'
+            }
+          } catch {
+            redirectTarget = '/dashboard/new'
+          }
+        }
 
         if (active) {
           setStatus('success')

--- a/osakamenesu/apps/web/src/app/dashboard/page.tsx
+++ b/osakamenesu/apps/web/src/app/dashboard/page.tsx
@@ -1,8 +1,60 @@
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
+
+import { buildApiUrl } from '@/lib/api'
+
+const INTERNAL_API_BASE =
+  process.env.OSAKAMENESU_API_INTERNAL_BASE ||
+  process.env.API_INTERNAL_BASE ||
+  process.env.NEXT_PUBLIC_OSAKAMENESU_API_BASE ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  '/api'
+
+function serializeCookieHeader(): string | undefined {
+  const store = cookies()
+  const entries = store.getAll()
+  if (!entries.length) {
+    return undefined
+  }
+  return entries.map((entry) => `${entry.name}=${entry.value}`).join('; ')
+}
+
+async function resolveFirstDashboardShopId(): Promise<string | null> {
+  const cookieHeader = serializeCookieHeader()
+  const url = buildApiUrl(INTERNAL_API_BASE, 'api/dashboard/shops?limit=1')
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+      cache: 'no-store',
+      credentials: cookieHeader ? 'omit' : 'include',
+    })
+
+    if (!res.ok) {
+      return null
+    }
+
+    const data = (await res.json().catch(() => undefined)) as
+      | { shops?: Array<{ id?: string }> }
+      | undefined
+
+    const first = data?.shops?.[0]
+    return typeof first?.id === 'string' ? first.id : null
+  } catch {
+    return null
+  }
+}
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-export default function DashboardIndexPage() {
-  redirect('/dashboard/favorites')
+export default async function DashboardIndexPage() {
+  const firstShopId = await resolveFirstDashboardShopId()
+
+  if (firstShopId) {
+    redirect(`/dashboard/${firstShopId}`)
+  }
+
+  redirect('/dashboard/new')
 }

--- a/osakamenesu/services/api/app/schemas.py
+++ b/osakamenesu/services/api/app/schemas.py
@@ -677,6 +677,18 @@ class DashboardShopStaff(BaseModel):
     specialties: List[str] = Field(default_factory=list)
 
 
+class DashboardShopSummaryItem(BaseModel):
+    id: UUID
+    name: str
+    area: Optional[str] = None
+    status: Optional[str] = None
+    updated_at: Optional[datetime] = None
+
+
+class DashboardShopListResponse(BaseModel):
+    shops: List[DashboardShopSummaryItem] = Field(default_factory=list)
+
+
 class DashboardShopProfileResponse(BaseModel):
     id: UUID
     slug: Optional[str] = None


### PR DESCRIPTION
## Summary
- add /api/dashboard/shops list endpoint so the dashboard can discover available profiles
- update auth completion and /dashboard landing to send admins to the first profile (or creation flow)
- keep site logins untouched while ensuring admin sessions arrive at an editable screen

## Testing
- pytest services/api/app/tests/test_dashboard_shops.py
- npm run lint