### PR TITLE
feat: セラピストIDと店舗お気に入りUIの拡張

### DIFF
--- a/osakamenesu/apps/web/src/app/search/page.tsx
+++ b/osakamenesu/apps/web/src/app/search/page.tsx
@@ -1,5 +1,6 @@
 import SearchFilters from '@/components/SearchFilters'
 import ShopCard, { type ShopHit } from '@/components/shop/ShopCard'
+import { ShopFavoritesProvider } from '@/components/shop/ShopFavoritesProvider'
 import TherapistCard, { type TherapistHit } from '@/components/staff/TherapistCard'
 import { TherapistFavoritesProvider } from '@/components/staff/TherapistFavoritesProvider'
 import { Badge } from '@/components/ui/Badge'
@@ -594,7 +595,8 @@ export default async function SearchPage({ searchParams }: { searchParams: Param
           ) : null}
 
           {showShopSection ? (
-            <Section
+            <ShopFavoritesProvider>
+              <Section
               id="search-results"
               ariaLive="polite"
               title={`店舗検索結果 ${Intl.NumberFormat('ja-JP').format(shopTotal)}件`}
@@ -676,7 +678,8 @@ export default async function SearchPage({ searchParams }: { searchParams: Param
                   )}
                 </div>
               </nav>
-            </Section>
+              </Section>
+            </ShopFavoritesProvider>
           ) : null}
 
           {!showTherapistSection && !showShopSection ? (

--- a/osakamenesu/apps/web/src/components/FavoriteHeartIcon.tsx
+++ b/osakamenesu/apps/web/src/components/FavoriteHeartIcon.tsx
@@ -1,0 +1,24 @@
+type FavoriteHeartIconProps = {
+  filled: boolean
+  className?: string
+}
+
+export function FavoriteHeartIcon({ filled, className }: FavoriteHeartIconProps) {
+  const classes = ['h-5 w-5', className].filter(Boolean).join(' ')
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      fill={filled ? '#ef4444' : 'none'}
+      className={classes}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M4.318 6.318a4.5 4.5 0 0 1 6.364 0L12 7.636l1.318-1.318a4.5 4.5 0 1 1 6.364 6.364L12 20.364l-7.682-7.682a4.5 4.5 0 0 1 0-6.364z"
+      />
+    </svg>
+  )
+}

--- a/osakamenesu/apps/web/src/components/shop/ShopCard.tsx
+++ b/osakamenesu/apps/web/src/components/shop/ShopCard.tsx
@@ -1,9 +1,13 @@
+"use client"
+
 import Image from 'next/image'
 import Link from 'next/link'
 
+import { FavoriteHeartIcon } from '@/components/FavoriteHeartIcon'
 import { Badge } from '@/components/ui/Badge'
 import { Card } from '@/components/ui/Card'
 import { Chip } from '@/components/ui/Chip'
+import { useShopFavorites } from './ShopFavoritesProvider'
 
 export type Promotion = {
   label: string
@@ -107,6 +111,9 @@ function getProfileHref(hit: ShopHit) {
 
 export function ShopCard({ hit }: { hit: ShopHit }) {
   const availability = getAvailability(hit)
+  const { isFavorite, toggleFavorite, isProcessing } = useShopFavorites()
+  const favorite = isFavorite(hit.id)
+  const processing = isProcessing(hit.id)
   const distanceLabel = (() => {
     if (hit.distance_km == null) return null
     if (hit.distance_km < 0.1) return '駅チカ'
@@ -124,11 +131,35 @@ export function ShopCard({ hit }: { hit: ShopHit }) {
     ? hit.promotions.find((promo) => promo && promo.label)
     : undefined
   const promotionLabel = primaryPromotion?.label || (hit.has_promotions ? '特典あり' : null)
-  const additionalPromotionCount = Math.max((hit.promotion_count ?? (primaryPromotion ? hit.promotions?.length ?? 1 : 0)) - (primaryPromotion ? 1 : 0), 0)
+  const additionalPromotionCount = Math.max(
+    (hit.promotion_count ?? (primaryPromotion ? hit.promotions?.length ?? 1 : 0)) - (primaryPromotion ? 1 : 0),
+    0,
+  )
+
+  const buttonLabel = favorite ? 'お気に入りから削除' : 'お気に入りに追加'
+  const shopHref = getProfileHref(hit)
 
   return (
-    <Link href={getProfileHref(hit)} className="block focus:outline-none" prefetch>
-      <Card interactive className="h-full" data-testid="shop-card">
+    <Card interactive className="relative h-full" data-testid="shop-card">
+      <button
+        type="button"
+        aria-pressed={favorite}
+        aria-label={buttonLabel}
+        title={buttonLabel}
+        disabled={processing}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          void toggleFavorite(hit.id)
+        }}
+        className={`absolute right-3 top-3 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full border border-neutral-borderLight bg-white/90 text-brand-primary shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary ${
+          favorite ? 'text-red-500' : ''
+        } ${processing ? 'opacity-60' : 'hover:bg-white'}`}
+      >
+        <FavoriteHeartIcon filled={favorite} />
+        <span className="sr-only">{buttonLabel}</span>
+      </button>
+      <Link href={shopHref} className="group block h-full focus:outline-none" prefetch>
         <div className="relative aspect-[4/3] bg-neutral-surfaceAlt">
           {hit.lead_image_url ? (
             <Image
@@ -136,7 +167,7 @@ export function ShopCard({ hit }: { hit: ShopHit }) {
               alt={`${hit.name} の写真`}
               fill
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-              className="object-cover"
+              className="object-cover transition duration-300 group-hover:scale-105"
               priority={false}
             />
           ) : null}
@@ -157,34 +188,30 @@ export function ShopCard({ hit }: { hit: ShopHit }) {
           ) : null}
         </div>
 
-          <div className="space-y-3 p-4">
-            <div>
-              <div className="flex items-start justify-between gap-2">
-                <h3 className="text-lg font-semibold tracking-tight text-neutral-text group-hover:text-brand-primary">
-                  {hit.name}
-                </h3>
-                {availability ? (
-                  <Badge variant={availability.tone === 'success' ? 'success' : 'neutral'}>{availability.label}</Badge>
-                ) : null}
-              </div>
-              {hit.store_name ? (
-                <p className="text-sm text-neutral-textMuted">{hit.store_name}</p>
-              ) : null}
-              <p className="text-sm text-neutral-textMuted">
-                {hit.area_name || hit.area}
-                {hit.address ? `｜${hit.address}` : ''}
-              </p>
-              {hit.ranking_reason ? (
-                <p className="mt-1 text-xs text-neutral-textMuted line-clamp-2">{hit.ranking_reason}</p>
+        <div className="space-y-3 p-4">
+          <div>
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="text-lg font-semibold tracking-tight text-neutral-text transition group-hover:text-brand-primary">
+                {hit.name}
+              </h3>
+              {availability ? (
+                <Badge variant={availability.tone === 'success' ? 'success' : 'neutral'}>{availability.label}</Badge>
               ) : null}
             </div>
+            {hit.store_name ? <p className="text-sm text-neutral-textMuted">{hit.store_name}</p> : null}
+            <p className="text-sm text-neutral-textMuted">
+              {hit.area_name || hit.area}
+              {hit.address ? `｜${hit.address}` : ''}
+            </p>
+            {hit.ranking_reason ? (
+              <p className="mt-1 text-xs text-neutral-textMuted line-clamp-2">{hit.ranking_reason}</p>
+            ) : null}
+          </div>
 
-            <div className="flex flex-wrap items-center gap-3 text-sm">
-              <span className="font-semibold text-brand-primaryDark">{formatPriceRange(hit.min_price, hit.max_price)}</span>
-              {hit.price_band_label ? (
-                <span className="text-xs text-neutral-textMuted">{hit.price_band_label}</span>
-              ) : null}
-              {hit.rating ? (
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <span className="font-semibold text-brand-primaryDark">{formatPriceRange(hit.min_price, hit.max_price)}</span>
+            {hit.price_band_label ? <span className="text-xs text-neutral-textMuted">{hit.price_band_label}</span> : null}
+            {hit.rating ? (
               <span className="flex items-center gap-1 text-neutral-text">
                 <span aria-hidden className="text-amber-400">★</span>
                 <span className="font-semibold">{hit.rating.toFixed(1)}</span>
@@ -193,11 +220,11 @@ export function ShopCard({ hit }: { hit: ShopHit }) {
             ) : null}
             {hit.online_reservation ? <Badge variant="brand">オンライン予約OK</Badge> : null}
             {hit.has_discounts ? <Badge variant="outline" className="text-xs">クーポン</Badge> : null}
-            </div>
+          </div>
 
-            {Array.isArray(hit.service_tags) && hit.service_tags.length ? (
-              <div className="flex flex-wrap gap-2">
-                {hit.service_tags.slice(0, 4).map((tag) => (
+          {Array.isArray(hit.service_tags) && hit.service_tags.length ? (
+            <div className="flex flex-wrap gap-2">
+              {hit.service_tags.slice(0, 4).map((tag) => (
                 <span
                   key={tag}
                   className="inline-flex items-center rounded-badge border border-neutral-borderLight bg-neutral-surfaceAlt px-2 py-0.5 text-[12px] text-neutral-text"
@@ -219,12 +246,10 @@ export function ShopCard({ hit }: { hit: ShopHit }) {
             <div className="text-xs text-neutral-textMuted">写メ日記 {hit.diary_count}件掲載</div>
           ) : null}
 
-          {updatedLabel ? (
-            <div className="text-xs text-neutral-textMuted">{updatedLabel}</div>
-          ) : null}
+          {updatedLabel ? <div className="text-xs text-neutral-textMuted">{updatedLabel}</div> : null}
         </div>
-      </Card>
-    </Link>
+      </Link>
+    </Card>
   )
 }
 

--- a/osakamenesu/apps/web/src/components/shop/ShopFavoritesProvider.tsx
+++ b/osakamenesu/apps/web/src/components/shop/ShopFavoritesProvider.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+
+import { ToastContainer, useToast } from '@/components/useToast'
+
+type ShopFavoriteRecord = {
+  shopId: string
+  createdAt: string
+}
+
+type ShopFavoritesContextValue = {
+  favorites: Map<string, ShopFavoriteRecord>
+  isAuthenticated: boolean | null
+  loading: boolean
+  isFavorite: (shopId: string) => boolean
+  isProcessing: (shopId: string) => boolean
+  toggleFavorite: (shopId: string) => Promise<void>
+}
+
+const ShopFavoritesContext = createContext<ShopFavoritesContextValue | undefined>(undefined)
+
+function normalizeId(value: string | null | undefined): string | null {
+  if (value == null) return null
+  const trimmed = String(value).trim()
+  return trimmed ? trimmed : null
+}
+
+export function ShopFavoritesProvider({ children }: { children: React.ReactNode }) {
+  const [favorites, setFavorites] = useState<Map<string, ShopFavoriteRecord>>(new Map())
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+  const [pending, setPending] = useState<Set<string>>(new Set())
+  const mutationVersionRef = useRef(0)
+  const keyVersionRef = useRef(new Map<string, number>())
+  const { toasts, push, remove } = useToast()
+
+  useEffect(() => {
+    let active = true
+    const fetchVersion = mutationVersionRef.current
+
+    async function loadFavorites() {
+      setLoading(true)
+      try {
+        const res = await fetch('/api/favorites', {
+          credentials: 'include',
+        })
+
+        if (!active) return
+
+        if (res.status === 401) {
+          setIsAuthenticated(false)
+          setFavorites(new Map())
+          keyVersionRef.current.clear()
+          setLoading(false)
+          return
+        }
+
+        if (!res.ok) {
+          throw new Error(`failed_to_fetch_shop_favorites_${res.status}`)
+        }
+
+        const data = (await res.json()) as Array<{
+          shop_id?: string
+          created_at?: string
+        }>
+
+        const next = new Map<string, ShopFavoriteRecord>()
+        for (const entry of data ?? []) {
+          const shopId = normalizeId(entry.shop_id)
+          if (!shopId) continue
+          next.set(shopId, {
+            shopId,
+            createdAt: entry.created_at ?? new Date().toISOString(),
+          })
+        }
+
+        setFavorites((prev) => {
+          if (!active) return prev
+
+          if (mutationVersionRef.current === fetchVersion) {
+            keyVersionRef.current.clear()
+            next.forEach((record, key) => {
+              keyVersionRef.current.set(key, fetchVersion)
+            })
+            return next
+          }
+
+          const merged = new Map(prev)
+          const serverKeys = new Set(next.keys())
+
+          next.forEach((record, key) => {
+            const version = keyVersionRef.current.get(key) ?? 0
+            if (version <= fetchVersion) {
+              merged.set(key, record)
+              keyVersionRef.current.set(key, fetchVersion)
+            }
+          })
+
+          for (const key of Array.from(merged.keys())) {
+            if (!serverKeys.has(key)) {
+              const version = keyVersionRef.current.get(key) ?? 0
+              if (version <= fetchVersion) {
+                merged.delete(key)
+                keyVersionRef.current.delete(key)
+              }
+            }
+          }
+
+          return merged
+        })
+        setIsAuthenticated(true)
+      } catch (error) {
+        if (!active) return
+        setIsAuthenticated((prev) => (prev === null ? null : prev))
+        push('error', 'お気に入りの読み込みに失敗しました。時間をおいて再度お試しください。')
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
+      }
+    }
+
+    loadFavorites()
+    return () => {
+      active = false
+    }
+  }, [push])
+
+  const isFavorite = useCallback(
+    (shopId: string) => {
+      const normalized = normalizeId(shopId)
+      if (!normalized) return false
+      return favorites.has(normalized)
+    },
+    [favorites]
+  )
+
+  const isProcessing = useCallback(
+    (shopId: string) => {
+      const normalized = normalizeId(shopId)
+      if (!normalized) return false
+      return pending.has(normalized)
+    },
+    [pending]
+  )
+
+  const toggleFavorite = useCallback(
+    async (shopId: string) => {
+      const normalizedShopId = normalizeId(shopId)
+
+      if (!normalizedShopId) {
+        push('error', 'この店舗はお気に入り登録に対応していません。')
+        return
+      }
+
+      if (isAuthenticated === false) {
+        push('error', 'お気に入り機能を利用するにはログインが必要です。')
+        return
+      }
+
+      setPending((prev) => {
+        const next = new Set(prev)
+        next.add(normalizedShopId)
+        return next
+      })
+
+      const currentlyFavorite = favorites.has(normalizedShopId)
+
+      try {
+        if (currentlyFavorite) {
+          const res = await fetch(`/api/favorites/${encodeURIComponent(normalizedShopId)}`, {
+            method: 'DELETE',
+            credentials: 'include',
+          })
+
+          if (res.status === 401) {
+            setIsAuthenticated(false)
+            setFavorites(new Map())
+            push('error', 'お気に入りを削除するにはログインしてください。')
+            return
+          }
+
+          if (!res.ok && res.status !== 404) {
+            throw new Error(`failed_to_remove_shop_favorite_${res.status}`)
+          }
+
+          const nextVersion = mutationVersionRef.current + 1
+          mutationVersionRef.current = nextVersion
+          keyVersionRef.current.set(normalizedShopId, nextVersion)
+          setFavorites((prev) => {
+            const next = new Map(prev)
+            next.delete(normalizedShopId)
+            return next
+          })
+          push('success', 'お気に入りから削除しました。')
+        } else {
+          const res = await fetch('/api/favorites', {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ shop_id: normalizedShopId }),
+          })
+
+          if (res.status === 401) {
+            setIsAuthenticated(false)
+            setFavorites(new Map())
+            push('error', 'お気に入り機能を利用するにはログインが必要です。')
+            return
+          }
+
+          if (!res.ok) {
+            throw new Error(`failed_to_add_shop_favorite_${res.status}`)
+          }
+
+          const data = (await res.json()) as {
+            shop_id?: string
+            created_at?: string
+          }
+
+          const responseShopId = normalizeId(data?.shop_id) ?? normalizedShopId
+          const createdAt = data?.created_at ?? new Date().toISOString()
+          const nextVersion = mutationVersionRef.current + 1
+          mutationVersionRef.current = nextVersion
+          keyVersionRef.current.set(responseShopId, nextVersion)
+          setFavorites((prev) => {
+            const next = new Map(prev)
+            next.set(responseShopId, {
+              shopId: responseShopId,
+              createdAt,
+            })
+            return next
+          })
+          setIsAuthenticated(true)
+          push('success', 'お気に入りに追加しました。')
+        }
+      } catch (error) {
+        const message = currentlyFavorite ? 'お気に入りの削除に失敗しました。' : 'お気に入りの追加に失敗しました。'
+        push('error', message)
+      } finally {
+        setPending((prev) => {
+          const next = new Set(prev)
+          next.delete(normalizedShopId)
+          return next
+        })
+      }
+    },
+    [favorites, isAuthenticated, push]
+  )
+
+  const value = useMemo<ShopFavoritesContextValue>(
+    () => ({
+      favorites,
+      isAuthenticated,
+      loading,
+      isFavorite,
+      isProcessing,
+      toggleFavorite,
+    }),
+    [favorites, isAuthenticated, isFavorite, isProcessing, loading, toggleFavorite]
+  )
+
+  return (
+    <ShopFavoritesContext.Provider value={value}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={remove} />
+    </ShopFavoritesContext.Provider>
+  )
+}
+
+export function useShopFavorites(): ShopFavoritesContextValue {
+  const context = useContext(ShopFavoritesContext)
+  if (!context) {
+    throw new Error('useShopFavorites must be used within a ShopFavoritesProvider')
+  }
+  return context
+}

--- a/osakamenesu/apps/web/src/components/shop/__tests__/ShopFavoritesProvider.test.tsx
+++ b/osakamenesu/apps/web/src/components/shop/__tests__/ShopFavoritesProvider.test.tsx
@@ -1,0 +1,136 @@
+import React, { ReactNode } from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ShopFavoritesProvider, useShopFavorites } from '../ShopFavoritesProvider'
+
+const originalFetch = global.fetch
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  })
+}
+
+function wrapperFactory() {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <ShopFavoritesProvider>{children}</ShopFavoritesProvider>
+  }
+}
+
+describe('ShopFavoritesProvider', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    global.fetch = originalFetch
+  })
+
+  it('loads existing favorites on mount', async () => {
+    const fetchMock = vi.fn()
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([{ shop_id: 's-1', created_at: '2024-01-01T00:00:00Z' }]),
+    )
+    global.fetch = fetchMock
+
+    const { result } = renderHook(() => useShopFavorites(), { wrapper: wrapperFactory() })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.isFavorite('s-1')).toBe(true)
+    expect(result.current.isAuthenticated).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds a favorite via toggleFavorite', async () => {
+    const fetchMock = vi.fn()
+    fetchMock.mockResolvedValueOnce(jsonResponse([])) // initial load
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ shop_id: 's-2', created_at: '2024-02-02T10:00:00Z' }, { status: 201 }),
+    )
+    global.fetch = fetchMock
+
+    const { result } = renderHook(() => useShopFavorites(), { wrapper: wrapperFactory() })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.toggleFavorite('s-2')
+    })
+
+    expect(result.current.isFavorite('s-2')).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('removes a favorite via toggleFavorite', async () => {
+    const fetchMock = vi.fn()
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ shop_id: 's-remove', created_at: '2024-03-03T09:00:00Z' }]))
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+    global.fetch = fetchMock
+
+    const { result } = renderHook(() => useShopFavorites(), { wrapper: wrapperFactory() })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.isFavorite('s-remove')).toBe(true)
+
+    await act(async () => {
+      await result.current.toggleFavorite('s-remove')
+    })
+
+    expect(result.current.isFavorite('s-remove')).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('marks unauthenticated users when initial fetch returns 401 and prevents toggles', async () => {
+    const fetchMock = vi.fn()
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }))
+    global.fetch = fetchMock
+
+    const { result } = renderHook(() => useShopFavorites(), { wrapper: wrapperFactory() })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.isAuthenticated).toBe(false)
+
+    await act(async () => {
+      await result.current.toggleFavorite('s-x')
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(result.current.isFavorite('s-x')).toBe(false)
+  })
+
+  it('keeps optimistic addition when initial fetch resolves later', async () => {
+    const fetchMock = vi.fn()
+    let resolveInitial: ((response: Response) => void) | undefined
+
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveInitial = resolve
+        }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ shop_id: 's-late', created_at: '2024-04-04T04:00:00Z' }, { status: 201 }),
+    )
+    global.fetch = fetchMock
+
+    const { result } = renderHook(() => useShopFavorites(), { wrapper: wrapperFactory() })
+
+    await act(async () => {
+      await result.current.toggleFavorite('s-late')
+    })
+
+    expect(result.current.isFavorite('s-late')).toBe(true)
+
+    resolveInitial?.(jsonResponse([]))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.isFavorite('s-late')).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/osakamenesu/apps/web/src/components/staff/TherapistCard.tsx
+++ b/osakamenesu/apps/web/src/components/staff/TherapistCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo } from 'react'
 
+import { FavoriteHeartIcon } from '@/components/FavoriteHeartIcon'
 import { Badge } from '@/components/ui/Badge'
 import { Card } from '@/components/ui/Card'
 import { useTherapistFavorites } from './TherapistFavoritesProvider'
@@ -38,24 +39,6 @@ function buildStaffHref(hit: TherapistHit) {
   return `/profiles/${base}/staff/${encodeURIComponent(hit.staffId)}`
 }
 
-function HeartIcon({ filled }: { filled: boolean }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={1.8}
-      fill={filled ? '#ef4444' : 'none'}
-      className="h-5 w-5"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M4.318 6.318a4.5 4.5 0 0 1 6.364 0L12 7.636l1.318-1.318a4.5 4.5 0 1 1 6.364 6.364L12 20.364l-7.682-7.682a4.5 4.5 0 0 1 0-6.364z"
-      />
-    </svg>
-  )
-}
 
 export function TherapistCard({ hit }: { hit: TherapistHit }) {
   const { isFavorite, toggleFavorite, isProcessing } = useTherapistFavorites()
@@ -88,7 +71,7 @@ export function TherapistCard({ hit }: { hit: TherapistHit }) {
           favorite ? 'text-red-500' : ''
         } ${processing ? 'opacity-60' : 'hover:bg-white'}`}
       >
-        <HeartIcon filled={favorite} />
+        <FavoriteHeartIcon filled={favorite} />
         <span className="sr-only">{favorite ? 'お気に入りから削除' : 'お気に入りに追加'}</span>
       </button>
       <Link href={staffHref} className="block focus:outline-none group">

--- a/osakamenesu/services/api/app/utils/profiles.py
+++ b/osakamenesu/services/api/app/utils/profiles.py
@@ -65,6 +65,113 @@ def _count_published_diaries(profile: models.Profile, contact_json: dict) -> int
 from .. import models
 
 
+
+def _normalize_text(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    return candidate or None
+
+
+def _collect_staff_specialties(raw: Any) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    cleaned: list[str] = []
+    for entry in raw:
+        normalized = _normalize_text(entry)
+        if normalized:
+            cleaned.append(normalized)
+    return cleaned
+
+
+
+def _build_staff_preview(profile: models.Profile, contact_json: dict[str, Any]) -> list[dict[str, Any]]:
+    """Serialize staff preview with therapist UUIDs when available."""
+    therapists: list[models.Therapist] = []
+    try:
+        cached = profile.__dict__.get('therapists')
+        if cached:
+            therapists = list(cached or [])
+    except Exception:
+        therapists = []
+
+    published = [t for t in therapists if getattr(t, 'status', None) == 'published']
+    therapist_by_id: dict[str, models.Therapist] = {str(t.id): t for t in published}
+    therapist_by_name: dict[str, list[models.Therapist]] = defaultdict(list)
+    for therapist in published:
+        key = (_normalize_text(therapist.name) or '').casefold()
+        if key:
+            therapist_by_name[key].append(therapist)
+
+    raw_staff = contact_json.get('staff') if isinstance(contact_json, dict) else None
+    contact_entries: list[dict[str, Any]] = []
+    if isinstance(raw_staff, list):
+        contact_entries = [entry for entry in raw_staff if isinstance(entry, dict)]
+
+    preview: list[dict[str, Any]] = []
+    used_ids: set[str] = set()
+
+    for entry in contact_entries:
+        name = _normalize_text(entry.get('name') or entry.get('staff_name'))
+        if not name:
+            continue
+        alias = _normalize_text(entry.get('alias'))
+        headline = _normalize_text(entry.get('headline'))
+        avatar_url = _normalize_text(entry.get('avatar_url') or entry.get('photo_url') or entry.get('image'))
+        rating = _safe_float(entry.get('rating'))
+        review_count = _safe_int(entry.get('review_count'))
+        specialties = _collect_staff_specialties(entry.get('specialties'))
+
+        raw_id = entry.get('id')
+        therapist_id = _normalize_text(raw_id) if raw_id is not None else None
+        matched: Optional[models.Therapist] = None
+        if therapist_id and therapist_id in therapist_by_id:
+            matched = therapist_by_id[therapist_id]
+        else:
+            key = name.casefold()
+            candidates = therapist_by_name.get(key, [])
+            matched = next((candidate for candidate in candidates if str(candidate.id) not in used_ids), None)
+
+        if matched:
+            therapist_id = str(matched.id)
+            used_ids.add(therapist_id)
+
+        preview.append(
+            {
+                'id': therapist_id,
+                'name': name,
+                'alias': alias,
+                'headline': headline,
+                'rating': rating,
+                'review_count': review_count,
+                'avatar_url': avatar_url,
+                'specialties': specialties,
+            }
+        )
+
+    unmatched = [t for t in published if str(t.id) not in used_ids]
+    for therapist in unmatched:
+        specialties = _collect_staff_specialties(list(getattr(therapist, 'specialties', []) or []))
+        photo_urls = list(getattr(therapist, 'photo_urls', []) or [])
+        preview.append(
+            {
+                'id': str(therapist.id),
+                'name': therapist.name,
+                'alias': _normalize_text(therapist.alias),
+                'headline': _normalize_text(therapist.headline),
+                'rating': None,
+                'review_count': None,
+                'avatar_url': _normalize_text(photo_urls[0]) if photo_urls else None,
+                'specialties': specialties,
+            }
+        )
+
+    return preview
+
+
 def _safe_int(v: object) -> Optional[int]:
     try:
         if v is None:
@@ -375,6 +482,7 @@ def build_profile_doc(
     has_discounts = bool(profile.discounts)
     has_promotions = bool(promotions)
     diary_count = _count_published_diaries(profile, contact_json)
+    staff_preview = _build_staff_preview(profile, contact_json)
     return {
         "id": str(profile.id),
         "slug": profile.slug,
@@ -410,7 +518,7 @@ def build_profile_doc(
         "review_aspect_averages": review_aspect_averages,
         "review_aspect_counts": review_aspect_counts,
         "ranking_reason": ranking_reason,
-        "staff_preview": contact_json.get("staff"),
+        "staff_preview": staff_preview,
         "price_band": price_band_key,
         "price_band_label": price_band_label,
         "has_promotions": has_promotions,


### PR DESCRIPTION
## 概要
- 検索プロファイルに含まれるスタッフプレビューへセラピストUUIDを補完
- 店舗カード用のお気に入りプロバイダとハートボタンを追加し、API と同期
- 店舗お気に入りとプロファイル整合性のユニットテストを整備

## 動作確認
- python -m pytest app/tests/test_profiles.py
- npm run test:unit -- shop/__tests__/ShopFavoritesProvider.test.tsx
