### PR TITLE
CIでMeiliキーをSecret Managerから取得しCloud Runデプロイを安全化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,6 @@ jobs:
         env:
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
           DATABASE_URL: ${{ steps.resolve-db-url.outputs.database_url }}
-          MEILI_MASTER_KEY: ${{ secrets.MEILI_MASTER_KEY }}
           MEILI_HOST_FALLBACK: ${{ secrets.MEILI_HOST }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           SITE_BASE_URL: ${{ secrets.SITE_BASE_URL }}
@@ -461,11 +460,21 @@ jobs:
             exit 1
           fi
           echo "::add-mask::${MEILI_HOST_EFFECTIVE}"
+          declare -a ENV_VARS=(
+            "DATABASE_URL=${DATABASE_URL}"
+            "MEILI_HOST=${MEILI_HOST_EFFECTIVE}"
+            "SITE_BASE_URL=${SITE_BASE_URL}"
+            "MAIL_APIKEY=${MAIL_APIKEY}"
+            "MAIL_FROM_ADDRESS=${MAIL_FROM_ADDRESS}"
+            "MAIL_PROVIDER_BASE_URL=${MAIL_PROVIDER_BASE_URL}"
+          )
+          ENV_STRING=$(IFS=,; printf '%s' "${ENV_VARS[*]}")
           gcloud run services update "$CLOUD_RUN_API_SERVICE" \
             --region "$CLOUD_RUN_REGION" \
             --add-cloudsql-instances "${GCP_PROJECT_ID}:${CLOUD_RUN_REGION}:osakamenesu-pg" \
             --image "$IMAGE" \
-            --update-env-vars "DATABASE_URL=${DATABASE_URL},MEILI_HOST=${MEILI_HOST_EFFECTIVE},MEILI_MASTER_KEY=${MEILI_MASTER_KEY},ADMIN_API_KEY=${ADMIN_API_KEY},OSAKAMENESU_ADMIN_API_KEY=${ADMIN_API_KEY},SITE_BASE_URL=${SITE_BASE_URL},MAIL_APIKEY=${MAIL_APIKEY},MAIL_FROM_ADDRESS=${MAIL_FROM_ADDRESS},MAIL_PROVIDER_BASE_URL=${MAIL_PROVIDER_BASE_URL}"
+            --update-env-vars "$ENV_STRING" \
+            --set-secrets "MEILI_MASTER_KEY=MEILI_MASTER_KEY:latest,ADMIN_API_KEY=ADMIN_API_KEY:latest,OSAKAMENESU_ADMIN_API_KEY=OSAKAMENESU_ADMIN_API_KEY:latest"
 
       - name: Deploy osakamenesu-web to Cloud Run
         env:


### PR DESCRIPTION
## 概要
- CIの統合テストジョブで Secret Manager から Meili master key を取得するステップを追加
- Secret Manager 利用前に gcloud 認証ステップを追加
- Cloud Run デプロイで環境変数を安全に渡す実装へ変更し、MEILI_MASTER_KEY は set-secrets で注入

## テスト
- ワークフロー定義の変更のみのため未実行
