### PR TITLE
CI: write Cloud Run env file as YAML mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,11 +465,28 @@ jobs:
           echo "::add-mask::${MEILI_HOST_EFFECTIVE}"
           env_file=$(mktemp)
           trap 'rm -f "$env_file"' EXIT
-          printf "DATABASE_URL=%s\\n" "${DATABASE_URL}" >> "$env_file"
-          printf "MEILI_HOST=%s\\n" "${MEILI_HOST_EFFECTIVE}" >> "$env_file"
-          printf "SITE_BASE_URL=%s\\n" "${SITE_BASE_URL}" >> "$env_file"
-          printf "MAIL_FROM_ADDRESS=%s\\n" "${MAIL_FROM_ADDRESS}" >> "$env_file"
-          printf "MAIL_PROVIDER_BASE_URL=%s\\n" "${MAIL_PROVIDER_BASE_URL}" >> "$env_file"
+          MEILI_HOST_EFFECTIVE="$MEILI_HOST_EFFECTIVE" ENV_FILE="$env_file" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+
+def to_yaml_line(key: str, value: str) -> str:
+    return f"{key}: {json.dumps(value, ensure_ascii=False)}\n"
+
+
+env_file = Path(os.environ["ENV_FILE"])
+
+pairs = {
+    "DATABASE_URL": os.environ["DATABASE_URL"],
+    "MEILI_HOST": os.environ["MEILI_HOST_EFFECTIVE"],
+    "SITE_BASE_URL": os.environ["SITE_BASE_URL"],
+    "MAIL_FROM_ADDRESS": os.environ["MAIL_FROM_ADDRESS"],
+    "MAIL_PROVIDER_BASE_URL": os.environ["MAIL_PROVIDER_BASE_URL"],
+}
+
+env_file.write_text("".join(to_yaml_line(k, v) for k, v in pairs.items()), encoding="utf-8")
+PY
           gcloud run services update "$CLOUD_RUN_API_SERVICE" \
             --region "$CLOUD_RUN_REGION" \
             --remove-env-vars "MAIL_APIKEY" \


### PR DESCRIPTION
## Summary
- emit the temporary Cloud Run environment file as YAML key/value pairs compatible with --env-vars-file
- quote each value via json.dumps to preserve special characters safely

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_6903539683f48325b28880d179ef8f6b