### PR TITLE
chore(ci): add frontend lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,29 @@ jobs:
       - name: Run lint (placeholder)
         run: npm run lint
 
+  frontend-lint:
+    needs:
+      - web-lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: osakamenesu/apps/web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable pnpm via corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
   admin-e2e:
     needs:
       - web-lint


### PR DESCRIPTION
## Summary\n- add frontend lint job to CI (pnpm lint in apps/web)\n- leave typecheck out for now (pending TS cleanup); typecheck job removed from this PR to keep scope small\n\n## Notes\n- typecheck revealed many pre-existing TS errors; will handle in a separate PR before wiring typecheck into CI\n\n## Testing\n- not run (CI-only change)