### PR TITLE
chore(specs): add matching diff-spec scaffold

### DIFF
--- a/osakamenesu/docs/matching-tags.md
+++ b/osakamenesu/docs/matching-tags.md
@@ -1,0 +1,39 @@
+# Matching tag catalog
+
+Canonical list of matching-related tags used across backend + frontend. Field names appear as snake_case in API contracts and camelCase in TS/DB models.
+
+## mood_tag / moodTag
+- Purpose: captures therapist atmosphere; influences vibe alignment in matching.
+- Options: `calm`, `energetic`, `mature`, `friendly`.
+- Source: therapist profile fields and matching preference inputs.
+- Scoring: contributes to `moodFit` (weight 0.15) when guest preferences include weights for these tags.
+
+## style_tag / styleTag
+- Purpose: massage/therapy style intensity.
+- Options: `relax`, `strong`, `exciting`.
+- Source: therapist profile fields and matching preference inputs.
+- Scoring: contributes to `styleFit` (weight 0.1) using guest style preferences.
+
+## look_type / lookType
+- Purpose: visual/character vibe for therapist presentation.
+- Options: `cute`, `oneesan`, `beauty`, `gal`, `natural`, `cool`.
+- Source: therapist profile fields and matching preference inputs.
+- Scoring: contributes to `lookFit` (weight 0.05) using guest look preferences.
+
+## talk_level / talkLevel
+- Purpose: expected talkativeness during a session.
+- Options: `quiet`, `normal`, `talkative`.
+- Source: therapist profile fields and matching preference inputs.
+- Scoring: contributes to `talkFit` (weight 0.1) when guest talk preferences are provided.
+
+## contact_style / contactStyle
+- Purpose: communication/booking strictness preference.
+- Options: `strict`, `standard`, `relaxed`.
+- Source: therapist profile fields and admin inputs.
+- Scoring: not currently weighted; exposed for display and future use.
+
+## hobby_tags / hobbyTags
+- Purpose: free-form interests for vibe/context and future recommendations.
+- Options: free-form string list.
+- Source: therapist profile fields.
+- Scoring: not currently weighted; may be used in recommendations (e.g., similar-therapist) later.

--- a/osakamenesu/docs/specs.md
+++ b/osakamenesu/docs/specs.md
@@ -2,10 +2,19 @@
 
 - Base spec: `specs/matching/base.md` captures current guest matching behavior at a high level.
 - Diff specs: `specs/matching/diffs/<issue>-<slug>.md` record per-issue changes without rewriting the base.
+- Tag catalog: `docs/matching-tags.md` lists available matching tags and how they are used.
 
 ## Naming rules
 - Use filenames `specs/matching/diffs/<issue-number>-<short-kebab-slug>.md` (e.g., `141-guest-matching-log.md`).
 - Include both `Issue: #<number>` and the full GitHub issue URL in the Links section of each diff spec.
+
+## Matching domain overview
+- `specs/matching/base.md` — current guest matching flow and scoring inputs/weights.
+- `specs/matching/diffs/141-guest-matching-log.md` — search + selection logging via `GuestMatchLog` (best-effort, non-blocking).
+- `specs/matching/diffs/142-profile-tags.md` — therapist profile tags surfaced to matching/scoring and documented in `docs/matching-tags.md`.
+- `specs/matching/diffs/143-score-alignment.md` — backend scoring aligned with frontend weights and tag fits.
+- `specs/matching/diffs/144-similar-therapist-api.md` — planned similar-therapist recommendation endpoint (not yet implemented).
+- `docs/matching-tags.md` — canonical tag definitions/options for matching.
 
 ## How to use diff specs
 - For every matching-related issue, add or update a diff spec with the sections **Current behavior**, **Change (diff)**, **Non-goals**, and **Links**.

--- a/osakamenesu/specs/matching/base.md
+++ b/osakamenesu/specs/matching/base.md
@@ -6,11 +6,12 @@ Scope: guest-facing matching flow and scoring, kept lightweight so diffs can ext
 - Primary endpoint `POST /api/guest/matching/search` (used by the search form and the chat-style entry) accepts guest preferences and returns ordered therapist candidates.
 - Inputs (rough): area or shop ids, date/time window, optional course or therapist id, budget level (`low`/`mid`/`high`), optional weighted preferences for mood/style/look/talk/contact/hobby plus free-text notes; may include a guest token for continuity.
 - Output: list of therapist candidates sorted by `score`; each item includes therapist id/name, shop id/name, available slots (start/end), profile tags (`moodTag`/`styleTag`/`lookType`/`contactStyle`/`hobbyTags`), and a `breakdown` of score components for transparency.
+- Matching requests are best-effort logged to `guest_match_logs` with payload, candidates, and (when chosen) selected therapist/slot for analytics/tuning.
 
 ## Scoring (current)
 - Core availability score (0–1) comes from search filters (area/time/booking constraints) and is shared between frontend and backend callers.
 - Total score mirrors `apps/web/src/features/matching/computeMatchingScore.ts` weights: core 0.4, price fit 0.15, mood fit 0.15, talk fit 0.1, style fit 0.1, look fit 0.05, availability 0.05; missing data defaults to a neutral 0.5.
-- Tag usage: therapist profiles include `moodTag`, `styleTag`, `lookType`, `contactStyle`, and optional `hobbyTags`; guest prefs can express weights per tag. Contact/hobby tags are present for display/future scoring but are not yet weighted.
+- Tag usage: therapist profiles include `moodTag`, `styleTag`, `lookType`, `talkLevel`, `contactStyle`, and optional `hobbyTags`; guest prefs can express weights per tag. Mood/style/look/talk influence scoring; contact/hobby are present for display/future scoring.
 - Response `breakdown` echoes component scores to help debugging and frontend display.
 
 ## Related Notes

--- a/osakamenesu/specs/matching/diffs/142-profile-tags.md
+++ b/osakamenesu/specs/matching/diffs/142-profile-tags.md
@@ -1,14 +1,15 @@
 # Diff Spec: Therapist profile tags (#142)
 
 ## Current behavior (as of main)
-- Therapist profiles now carry `moodTag`, `styleTag`, `lookType`, `contactStyle`, and optional `hobbyTags` alongside existing fields.
-- Matching responses expose these tags so the UI and scoring can consume them.
-- Scoring uses mood/style/look tags when provided; missing tags fall back to neutral values.
+- Therapist profiles carry `moodTag`, `styleTag`, `lookType`, `talkLevel`, `contactStyle`, and optional `hobbyTags` alongside existing fields (see `docs/matching-tags.md`).
+- Matching responses expose these tags so the UI and scoring can consume them; talk and contact styles are returned for display even when not weighted.
+- Scoring uses mood/style/look/talk tags when provided; missing tags fall back to neutral values to avoid penalizing sparse data.
 
 ## Change in this issue (diff)
-- Implemented tag fields across persistence and API contracts; populated them through admin/profile inputs while keeping them optional for existing data.
+- Added tag fields across persistence and API contracts and populated them through admin/profile inputs while keeping them optional for existing data.
 - Surfaced tags in matching candidate payloads so frontend can display and weight them consistently.
-- Fed the new tags into backend scoring to match the frontend `computeMatchingScore` inputs.
+- Fed the new tags into backend scoring (mood/style/look/talk) to match the frontend `computeMatchingScore` inputs; contact/hobby remain display-only for now.
+- Documented the tag catalog in `docs/matching-tags.md`.
 
 ## Non-goals
 - No mandatory tagging or migration that blocks publish; empty tags remain valid.
@@ -16,6 +17,6 @@
 - No new UI or analytics for tag management beyond existing editors.
 
 ## Links
-- Issue: #142
-- Issue URL: https://github.com/osakamenesu/kakeru/issues/142
-- Related scoring alignment: #143 https://github.com/osakamenesu/kakeru/issues/143
+- Issue: #142 (https://github.com/osakamenesu/kakeru/issues/142)
+- Implemented by: #146, #147, #149
+- Tag catalog: `docs/matching-tags.md`

--- a/osakamenesu/specs/matching/diffs/143-score-alignment.md
+++ b/osakamenesu/specs/matching/diffs/143-score-alignment.md
@@ -1,7 +1,7 @@
 # Diff Spec: Matching score alignment (#143)
 
 ## Current behavior (as of main)
-- Backend `_score_candidate` matches frontend `computeMatchingScore` weights and defaults.
+- Backend `_score_candidate` matches frontend `computeMatchingScore` weights and defaults, including tag-based fits for mood/style/look/talk.
 - Missing tags or preferences default to a neutral 0.5 so incomplete data is not penalized.
 - API responses include a breakdown (`core`, `priceFit`, `moodFit`, `talkFit`, `styleFit`, `lookFit`, `availability`) used for ranking and debugging.
 
@@ -16,6 +16,6 @@
 - Response shape is unchanged beyond the existing breakdown fields.
 
 ## Links
-- Issue: #143
-- Issue URL: https://github.com/osakamenesu/kakeru/issues/143
+- Issue: #143 (https://github.com/osakamenesu/kakeru/issues/143)
+- Implemented by: #147, #146
 - Frontend helper: `osakamenesu/apps/web/src/features/matching/computeMatchingScore.ts`

--- a/osakamenesu/specs/matching/diffs/144-similar-therapist-api.md
+++ b/osakamenesu/specs/matching/diffs/144-similar-therapist-api.md
@@ -5,7 +5,7 @@
 - Recommendations rely on manual browsing; similarity to a chosen therapist is not exposed.
 
 ## Change in this issue (diff)
-- Planned: add a read-only endpoint (e.g., `GET /api/guest/matching/similar?therapist_id=...` or `/api/therapists/{id}/similar`) that returns a small list of similar therapists with similarity scores.
+- Planned (not yet implemented): add a read-only endpoint (e.g., `GET /api/guest/matching/similar?therapist_id=...` or `/api/therapists/{id}/similar`) that returns a small list of similar therapists with similarity scores.
 - Planned: compute similarity using existing profile signals (mood/style/look/contact/hobby tags, price level, shop/area proximity) and the same scoring breakdown shape used in matching responses.
 - Planned: response shape mirrors matching candidates (therapist/shop ids, name, tags, optional availability plus score/breakdown) so the frontend can reuse components.
 
@@ -15,5 +15,5 @@
 - Does not alter booking or availability logic; similarity is informational and does not reserve slots.
 
 ## Links
-- Issue: #144
-- Issue URL: https://github.com/osakamenesu/kakeru/issues/144
+- Issue: #144 (https://github.com/osakamenesu/kakeru/issues/144)
+- Status: planned; no implementing PR yet


### PR DESCRIPTION
## Summary\n- add matching base spec covering current guest matching flow and scoring weights\n- add per-issue diff specs (#141-#144) for logging, profile tags, score alignment, and planned similar-therapist API\n- add docs/specs.md to explain the base + diff spec workflow and naming convention; docs/structure only, no runtime behavior changes\n\n## Testing\n- not run (docs-only)