### PR TITLE
chore(specs): add speckit scaffold

### DIFF
--- a/docs/specs.md
+++ b/docs/specs.md
@@ -1,0 +1,19 @@
+# Specs workflow
+
+## Speckit
+- Location: `specs/speckit/<domain>/` (matching, reservations, auth).
+- Purpose: executable happy-path scenarios aligned with the Markdown base/diff specs in `specs/<domain>/`.
+- Naming: one YAML per scenario (e.g., `specs/speckit/matching/search.yaml`, `specs/speckit/auth/login-magic-link.yaml`).
+- Usage:
+  - Validate: `speckit validate specs/speckit`
+  - Run vs dev API: `speckit run <file> --base-url http://localhost:8000`
+  - CI (future): add a lightweight job to run `speckit validate specs/speckit` and optionally `speckit check specs/speckit --base-url $DEV_API`.
+- Domains covered in this scaffold:
+  - Matching: `/api/guest/matching/search`, `/api/guest/matching/similar`
+  - Reservations: availability lookup + reservation create (happy path)
+  - Auth: magic-link request/verify (dashboard scope)
+
+## Checklist for issues/PRs
+- [ ] Update or add a diff spec under `specs/<domain>/diffs/` (sections: Current / Change / Non-goals / Links with Issue# + URL)
+- [ ] If endpoints change, update/add speckit scenarios under `specs/speckit/<domain>/`
+- [ ] Link the relevant diff spec from the GitHub issue/PR description

--- a/specs/speckit/README.md
+++ b/specs/speckit/README.md
@@ -1,0 +1,16 @@
+# speckit scenarios
+
+Executable specs organized per domain under `specs/speckit/<domain>/`. Use these alongside the Markdown base/diff specs (see `specs/<domain>/` in main) to keep contracts in sync.
+
+Guidelines
+- Keep scenarios small and happy-path; add edge cases per issue when needed.
+- Note relevant diff IDs in comments/links inside the scenario files.
+- Allow extra response fields unless the contract requires strict matching.
+
+Local usage
+- Validate syntax: `speckit validate specs/speckit`
+- Run a scenario against dev API: `speckit run specs/speckit/matching/search.yaml --base-url http://localhost:8000`
+- (Optional) Generate mocks if enabled: `speckit mock specs/speckit/matching/search.yaml`
+
+CI suggestion (future)
+- Add a lightweight job to run `speckit validate specs/speckit` and, if a dev API is available, `speckit check specs/speckit --base-url $DEV_API`.

--- a/specs/speckit/auth/login-magic-link.yaml
+++ b/specs/speckit/auth/login-magic-link.yaml
@@ -1,0 +1,43 @@
+id: auth-magic-link-dashboard
+summary: Dashboard login via magic-link request + verify issuing a scoped session.
+domain: auth
+links:
+  - spec: specs/auth/base.md
+  - diff: specs/auth/diffs/85-magic-link-auth.md
+  - diff: specs/auth/diffs/88-split-admin-site-auth.md
+steps:
+  - id: request-link
+    endpoint:
+      method: POST
+      path: /api/auth/request-link
+      headers:
+        Content-Type: application/json
+      body:
+        email: admin@example.com
+        scope: dashboard
+    expect:
+      status: 202
+      json:
+        ok: true
+      notes:
+        - Envelope may include message_id or rate-limit info; accept additional fields.
+  - id: verify-link
+    endpoint:
+      method: POST
+      path: /api/auth/verify
+      headers:
+        Content-Type: application/json
+      body:
+        token: EXAMPLE-TOKEN
+    expect:
+      status: 200
+      json:
+        ok: true
+        scope: dashboard
+      cookies:
+        contains:
+          - name: auth_session
+      notes:
+        - Session cookie name may be scope-specific; accept either site or dashboard cookie names from settings.
+notes:
+  - Happy-path scaffold for #85/#88; token/email to be wired via fixtures when running checks.

--- a/specs/speckit/matching/search.yaml
+++ b/specs/speckit/matching/search.yaml
@@ -1,0 +1,48 @@
+id: matching-search-happy
+summary: Guest matching search returns top/other candidates with tag-based breakdown.
+domain: matching
+links:
+  - spec: specs/matching/base.md
+  - diff: specs/matching/diffs/143-score-alignment.md
+endpoint:
+  method: POST
+  path: /api/guest/matching/search
+  headers:
+    Content-Type: application/json
+  body:
+    area: osaka
+    date: 2025-12-01
+    budget_level: mid
+    mood_pref: { calm: 1 }
+    style_pref: { relax: 1 }
+    look_pref: { natural: 1 }
+    talk_pref: { normal: 1 }
+expect:
+  status: 200
+  json:
+    top_matches:
+      - therapist_id: uuid
+        therapist_name: string
+        shop_id: uuid
+        shop_name: string
+        score: number
+        breakdown:
+          core: number
+          priceFit: number
+          moodFit: number
+          talkFit: number
+          styleFit: number
+          lookFit: number
+          availability: number
+        slots: []
+    other_candidates: []
+  rules:
+    - path: $.top_matches
+      description: returns list of scored candidates (at least 1 when available)
+      assert: len(value) >= 0
+    - path: $.top_matches[*].breakdown
+      description: breakdown components are normalized 0..1
+      assert: all(0 <= v <= 1 for v in value.values())
+notes:
+  - Shape mirrors FastAPI matching search (`top_matches`/`other_candidates`).
+  - Allow extra fields (e.g., summaries, photos) beyond those listed.

--- a/specs/speckit/matching/similar.yaml
+++ b/specs/speckit/matching/similar.yaml
@@ -1,0 +1,48 @@
+id: matching-similar-happy
+summary: Returns therapists similar to a target therapist with tag-based scores.
+domain: matching
+links:
+  - spec: specs/matching/base.md
+  - diff: specs/matching/diffs/144-similar-therapist-api.md
+endpoint:
+  method: GET
+  path: /api/guest/matching/similar
+  query:
+    therapist_id: 11111111-1111-1111-8888-111111111111
+    limit: 3
+expect:
+  status: 200
+  json:
+    base_therapist:
+      therapist_id: uuid
+      therapist_name: string
+      profile_id: uuid
+      profile_name: string
+      mood_tag: string
+      talk_level: string
+      style_tag: string
+      look_type: string
+      contact_style: string
+      hobby_tags: []
+    similar:
+      - therapist_id: uuid
+        therapist_name: string
+        profile_id: uuid
+        profile_name: string
+        score: number
+        breakdown:
+          mood: number
+          talk: number
+          style: number
+          look: number
+          contact: number
+          hobby: number
+  rules:
+    - path: $.similar
+      description: excludes base therapist
+      assert: all(item['therapist_id'] != $.base_therapist.therapist_id for item in value)
+    - path: $.similar
+      description: sorted by similarity score descending
+      assert: value == sorted(value, key=lambda i: i['score'], reverse=True)
+notes:
+  - Reflects implemented `/api/guest/matching/similar` (PR #150); focuses on ids/tags/score/breakdown. Allow extra fields as needed.

--- a/specs/speckit/reservations/search-and-book.yaml
+++ b/specs/speckit/reservations/search-and-book.yaml
@@ -1,0 +1,74 @@
+id: reservations-search-and-book
+summary: Guest checks availability and creates a reservation.
+domain: reservations
+links:
+  - spec: specs/reservations/base.md
+steps:
+  - id: availability
+    endpoint:
+      method: GET
+      path: /api/v1/shops/{shop_id}/availability
+      path_params:
+        shop_id: 11111111-1111-1111-8888-111111111111
+      query:
+        date_from: 2025-12-01
+        date_to: 2025-12-02
+    expect:
+      status: 200
+      json:
+        days:
+          - date: string
+            slots:
+              - start_at: string
+                end_at: string
+                staff_id: uuid
+                menu_id: uuid
+      rules:
+        - path: $.days[*].slots
+          description: at least one open slot exists across requested range
+          assert: any(len(slots) > 0 for slots in value)
+  - id: create-reservation
+    endpoint:
+      method: POST
+      path: /api/v1/reservations
+      headers:
+        Content-Type: application/json
+      body:
+        shop_id: 11111111-1111-1111-8888-111111111111
+        staff_id: 22222222-2222-2222-8888-222222222222
+        menu_id: 33333333-3333-3333-8888-333333333333
+        channel: web
+        desired_start: 2025-12-01T15:00:00Z
+        desired_end: 2025-12-01T16:00:00Z
+        notes: speckit demo booking
+        marketing_opt_in: false
+        customer:
+          name: Guest User
+          phone: "+819012345678"
+          email: guest@example.com
+          line_id: null
+          remark: null
+        preferred_slots:
+          - desired_start: 2025-12-01T15:00:00Z
+            desired_end: 2025-12-01T16:00:00Z
+            status: pending
+    expect:
+      status: 201
+      json:
+        id: uuid
+        status: string
+        shop_id: uuid
+        staff_id: uuid
+        menu_id: uuid
+        desired_start: string
+        desired_end: string
+        customer:
+          name: string
+          email: string
+      rules:
+        - path: $.status
+          description: reservation starts as pending or confirmed depending on rules
+          assert: value in ["pending", "confirmed"]
+notes:
+  - Happy-path scaffold; adjust ids/dates per fixtures when running locally.
+  - Allow additional fields (status_history, preferred_slots, timestamps, etc.).


### PR DESCRIPTION
## Summary\n- add speckit scaffold with happy-path scenarios per domain (matching search/similar, reservations availability+create, auth magic-link request/verify) under specs/speckit\n- add minimal docs/specs speckit section (location, naming, basic commands)\n- domain base/diff specs remain in their own PRs; no runtime or test changes\n\n## Testing\n- not run (docs-only)