### PR TITLE
feat(matching): show similar therapists section on guest staff detail

### DIFF
--- a/osakamenesu/apps/web/src/app/profiles/[id]/staff/[staffId]/page.tsx
+++ b/osakamenesu/apps/web/src/app/profiles/[id]/staff/[staffId]/page.tsx
@@ -13,6 +13,7 @@ import { TherapistSchedule } from '@/features/therapist/ui/TherapistSchedule'
 import { buildStaffIdentifier, staffMatchesIdentifier, slugifyStaffIdentifier } from '@/lib/staff'
 import { toLocalDateISO } from '@/lib/date'
 import { getJaFormatter } from '@/utils/date'
+import { SimilarTherapistsSection } from '@/features/matching/ui/SimilarTherapistsSection'
 import { fetchShop, type ShopDetail, type StaffSummary } from '../../page'
 
 function findStaff(shop: ShopDetail, staffId: string): StaffSummary | null {
@@ -536,6 +537,8 @@ export default async function StaffProfilePage({ params, searchParams }: StaffPa
             allowDemoSubmission={allowDemoSubmission}
           />
         </Card>
+
+        <SimilarTherapistsSection baseStaffId={staffId} />
 
         {otherStaff.length ? (
           <Section

--- a/osakamenesu/apps/web/src/features/matching/api.ts
+++ b/osakamenesu/apps/web/src/features/matching/api.ts
@@ -1,0 +1,77 @@
+export type SimilarTherapist = {
+  id: string
+  name: string
+  age: number | null
+  priceRank: number | null
+  moodTag?: string | null
+  styleTag?: string | null
+  lookType?: string | null
+  contactStyle?: string | null
+  hobbyTags: string[]
+  photoUrl?: string | null
+  isAvailableNow: boolean
+  score: number
+  photoSimilarity: number
+  tagSimilarity: number
+}
+
+export type SimilarTherapistResponse = {
+  baseStaffId: string
+  items: SimilarTherapist[]
+}
+
+export type SimilarTherapistRequest = {
+  staffId: string
+  limit?: number
+  minScore?: number
+  shopId?: string
+  excludeUnavailable?: boolean
+}
+
+function normalizeItem(raw: any): SimilarTherapist {
+  return {
+    id: String(raw.id ?? ''),
+    name: raw.name ?? '',
+    age: raw.age ?? null,
+    priceRank: raw.price_rank ?? null,
+    moodTag: raw.mood_tag ?? null,
+    styleTag: raw.style_tag ?? null,
+    lookType: raw.look_type ?? null,
+    contactStyle: raw.contact_style ?? null,
+    hobbyTags: Array.isArray(raw.hobby_tags) ? raw.hobby_tags : [],
+    photoUrl: raw.photo_url ?? null,
+    isAvailableNow: Boolean(raw.is_available_now ?? true),
+    score: Number(raw.score ?? 0),
+    photoSimilarity: Number(raw.photo_similarity ?? raw.tag_similarity ?? 0),
+    tagSimilarity: Number(raw.tag_similarity ?? 0),
+  }
+}
+
+export async function fetchSimilarTherapists(
+  params: SimilarTherapistRequest,
+): Promise<SimilarTherapistResponse> {
+  const { staffId, limit = 8, minScore, shopId, excludeUnavailable } = params
+  const search = new URLSearchParams()
+  search.set('staff_id', staffId)
+  if (limit) search.set('limit', String(limit))
+  if (minScore !== undefined) search.set('min_score', String(minScore))
+  if (shopId) search.set('shop_id', shopId)
+  if (excludeUnavailable !== undefined) {
+    search.set('exclude_unavailable', String(excludeUnavailable))
+  }
+
+  const resp = await fetch(`/api/guest/matching/similar?${search.toString()}`, {
+    cache: 'no-store',
+  })
+
+  if (resp.status === 404) {
+    return { baseStaffId: staffId, items: [] }
+  }
+  if (!resp.ok) {
+    throw new Error(`fetchSimilarTherapists failed (${resp.status})`)
+  }
+  const body = await resp.json()
+  const items = Array.isArray(body.items) ? body.items.map(normalizeItem) : []
+  const baseStaffId = body.base_staff_id ?? body.baseStaffId ?? staffId
+  return { baseStaffId, items }
+}

--- a/osakamenesu/apps/web/src/features/matching/ui/SimilarTherapistsSection.test.tsx
+++ b/osakamenesu/apps/web/src/features/matching/ui/SimilarTherapistsSection.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import { SimilarTherapistsSection } from './SimilarTherapistsSection'
+
+const mockItems = [
+  {
+    id: 't1',
+    name: 'Therapist 1',
+    age: 24,
+    price_rank: 2,
+    mood_tag: 'calm',
+    style_tag: 'relax',
+    look_type: 'natural',
+    contact_style: 'gentle',
+    hobby_tags: ['anime'],
+    photo_url: 'https://example.com/photo1.jpg',
+    is_available_now: true,
+    score: 0.9,
+    photo_similarity: 0.9,
+    tag_similarity: 0.9,
+  },
+  {
+    id: 't2',
+    name: 'Therapist 2',
+    age: 26,
+    price_rank: 3,
+    mood_tag: 'cool',
+    style_tag: 'strong',
+    look_type: 'beauty',
+    contact_style: 'standard',
+    hobby_tags: ['golf'],
+    photo_url: 'https://example.com/photo2.jpg',
+    is_available_now: false,
+    score: 0.7,
+    photo_similarity: 0.7,
+    tag_similarity: 0.7,
+  },
+]
+
+describe('SimilarTherapistsSection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('calls API and renders cards when items exist', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ base_staff_id: 'base', items: mockItems }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<SimilarTherapistsSection baseStaffId="base" />)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('staff_id=base')
+    expect(url).toContain('limit=8')
+
+    await waitFor(() =>
+      expect(screen.getByText('この子に近いタイプ')).toBeInTheDocument(),
+    )
+    await waitFor(() =>
+      expect(screen.getAllByTestId('similar-card')).toHaveLength(mockItems.length),
+    )
+  })
+
+  it('hides section when items are empty', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ base_staff_id: 'base', items: [] }),
+    }))
+
+    render(<SimilarTherapistsSection baseStaffId="base" />)
+
+    await waitFor(() =>
+      expect(screen.queryByText('この子に近いタイプ')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('hides section on error', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+
+    render(<SimilarTherapistsSection baseStaffId="base" />)
+
+    await waitFor(() =>
+      expect(screen.queryByText('この子に近いタイプ')).not.toBeInTheDocument(),
+    )
+    consoleSpy.mockRestore()
+  })
+})

--- a/osakamenesu/apps/web/src/features/matching/ui/SimilarTherapistsSection.tsx
+++ b/osakamenesu/apps/web/src/features/matching/ui/SimilarTherapistsSection.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+
+import SafeImage from '@/components/SafeImage'
+import { Badge } from '@/components/ui/Badge'
+import { Card } from '@/components/ui/Card'
+import { Section } from '@/components/ui/Section'
+import { fetchSimilarTherapists, type SimilarTherapist } from '../api'
+
+type Props = {
+  baseStaffId: string
+  limit?: number
+  minScore?: number
+}
+
+const skeletonItems = Array.from({ length: 4 })
+
+function PriceLabel({ priceRank }: { priceRank: number | null }) {
+  if (priceRank === null || priceRank === undefined) return null
+  return <Badge variant="outline">価格帯: {priceRank}</Badge>
+}
+
+function TagsRow({ item }: { item: SimilarTherapist }) {
+  const tags = [item.moodTag, item.styleTag, item.lookType].filter(Boolean).slice(0, 2)
+  if (!tags.length) return null
+  return (
+    <div className="flex flex-wrap gap-2 text-[11px] text-neutral-textMuted">
+      {tags.map((tag, idx) => (
+        <span key={`${tag}-${idx}`} className="rounded-badge bg-neutral-surfaceAlt px-2 py-1">
+          {tag}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function AvailabilityBadge({ available }: { available: boolean }) {
+  if (available) {
+    return <Badge variant="success">◎ 予約可</Badge>
+  }
+  return <Badge variant="outline">× 満席</Badge>
+}
+
+export function SimilarTherapistsSection({ baseStaffId, limit = 8, minScore }: Props) {
+  const [items, setItems] = useState<SimilarTherapist[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    async function run() {
+      if (!baseStaffId) {
+        setItems([])
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetchSimilarTherapists({ staffId: baseStaffId, limit, minScore })
+        if (!mounted) return
+        setItems(res.items ?? [])
+      } catch (err) {
+        console.error('[similar-therapists] fetch failed', err)
+        if (!mounted) return
+        setError('failed')
+        setItems([])
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+    run()
+    return () => {
+      mounted = false
+    }
+  }, [baseStaffId, limit, minScore])
+
+  if (!loading && (error || items.length === 0)) {
+    return null
+  }
+
+  return (
+    <Section
+      title="この子に近いタイプ"
+      subtitle="タグ・価格・年齢の近さから似ているセラをピックアップ"
+      className="border border-neutral-borderLight/70 bg-white/90 shadow-lg shadow-neutral-950/5 backdrop-blur supports-[backdrop-filter]:bg-white/80"
+    >
+      {loading ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {skeletonItems.map((_, idx) => (
+            <Card key={idx} className="flex gap-3 p-3">
+              <div className="h-20 w-20 animate-pulse rounded-card bg-neutral-surfaceAlt" />
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="h-4 w-2/3 animate-pulse rounded bg-neutral-surfaceAlt" />
+                <div className="h-3 w-1/2 animate-pulse rounded bg-neutral-surfaceAlt" />
+                <div className="h-3 w-1/3 animate-pulse rounded bg-neutral-surfaceAlt" />
+              </div>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {items.map((item) => (
+            <Card
+              key={item.id}
+              className="flex gap-3 p-3 transition hover:border-brand-primary hover:shadow-sm"
+              data-testid="similar-card"
+            >
+              <div className="relative h-20 w-20 overflow-hidden rounded-card bg-neutral-surface">
+                <SafeImage
+                  src={item.photoUrl || undefined}
+                  alt={`${item.name}の写真`}
+                  width={80}
+                  height={80}
+                  className="h-full w-full object-cover"
+                  fallbackSrc="/images/placeholder-avatar.svg"
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-1 text-sm text-neutral-text">
+                <div className="flex items-center gap-2">
+                  <span className="text-base font-semibold text-neutral-text">{item.name}</span>
+                  {typeof item.age === 'number' ? (
+                    <span className="text-xs text-neutral-textMuted">{item.age}歳</span>
+                  ) : null}
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs text-neutral-textMuted">
+                  <PriceLabel priceRank={item.priceRank} />
+                  <AvailabilityBadge available={item.isAvailableNow} />
+                </div>
+                <TagsRow item={item} />
+                <div className="text-[11px] text-neutral-textMuted">
+                  スコア {item.score.toFixed(2)} / タグ {item.tagSimilarity.toFixed(2)}
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </Section>
+  )
+}


### PR DESCRIPTION
Summary\n- Add SimilarTherapistsSection to the guest staff detail page.\n- Fetch /api/guest/matching/similar on the detail page and render a "この子に近いタイプ" section.\n\nBehavior\n- On the guest staff detail page, call GET /api/guest/matching/similar?staff_id=...&limit=8.\n- Show up to 8 similar therapist cards (photo, name, age, price rank, a couple of tags, availability).\n- Hide the section when there are no similar items or when the API fails.\n\nTests\n- cd apps/web && pnpm test:unit