### PR TITLE
feat(api): align guest matching phase availability

### DIFF
--- a/osakamenesu/services/api/app/tests/test_guest_matching_api_availability.py
+++ b/osakamenesu/services/api/app/tests/test_guest_matching_api_availability.py
@@ -71,6 +71,7 @@ def test_search_availability_true(
             "date": "2025-01-01",
             "time_from": "10:00",
             "time_to": "11:00",
+            "phase": "narrow",
         },
     )
     assert res.status_code == 200
@@ -94,6 +95,7 @@ def test_search_availability_false(
             "date": "2025-01-01",
             "time_from": "10:00",
             "time_to": "11:00",
+            "phase": "narrow",
         },
     )
     assert res.status_code == 200


### PR DESCRIPTION
Align /api/guest/matching/search with specs for phase-based availability and scoring.\n\n- add phase/step_index/entry_source fields to request model (phase normalized)\n- apply spec score aggregation and availability handling per phase (explore/narrow/book) including defaults\n- update tests for phase behaviors and add coverage for explore/narrow/book and default fallbacks\n\nTests: \n- pytest services/api/app/tests/test_guest_matching_scoring.py services/api/app/tests/test_guest_matching_availability.py services/api/app/tests/test_guest_matching_api_availability.py\n- pre-commit hook ran full backend tests (190 passed, 7 skipped)