### PR TITLE
feat(api): log matching phase step and entry source

### DIFF
--- a/osakamenesu/services/api/alembic/versions/0034_add_guest_match_log_phase_step_entry.py
+++ b/osakamenesu/services/api/alembic/versions/0034_add_guest_match_log_phase_step_entry.py
@@ -1,0 +1,31 @@
+"""add phase/step_index/entry_source to guest_match_logs"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0034_add_guest_match_log_phase_step_entry"
+down_revision = "0033_merge_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guest_match_logs", sa.Column("phase", sa.String(length=32), nullable=True)
+    )
+    op.add_column(
+        "guest_match_logs", sa.Column("step_index", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "guest_match_logs",
+        sa.Column("entry_source", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("guest_match_logs", "entry_source")
+    op.drop_column("guest_match_logs", "step_index")
+    op.drop_column("guest_match_logs", "phase")

--- a/osakamenesu/services/api/app/models.py
+++ b/osakamenesu/services/api/app/models.py
@@ -254,6 +254,9 @@ class GuestMatchLog(Base):
     style_pref: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     look_pref: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     free_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    phase: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    step_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    entry_source: Mapped[str | None] = mapped_column(String(64), nullable=True)
     top_matches: Mapped[list[dict[str, Any]] | None] = mapped_column(
         JSONB, nullable=True
     )

--- a/osakamenesu/services/api/app/tests/test_guest_matching_logging.py
+++ b/osakamenesu/services/api/app/tests/test_guest_matching_logging.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import types
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    async def commit(self) -> None:
+        return None
+
+    async def rollback(self) -> None:
+        return None
+
+
+def _mk_candidate(name: str) -> dict[str, Any]:
+    return {
+        "id": name,
+        "name": name,
+        "shop_id": f"shop-{name}",
+        "shop_name": f"Shop {name}",
+        "price_rank": 2,
+        "mood_tag": "calm",
+        "style_tag": "relax",
+        "look_type": "natural",
+        "contact_style": "gentle",
+        "hobby_tags": ["anime"],
+        "age": 25,
+        "photo_url": "https://example.com/photo.jpg",
+        "photo_embedding": [1.0, 0.0, 0.0],
+        "slots": [],
+    }
+
+
+def _make_client(session: FakeSession, matching_module, monkeypatch) -> TestClient:
+    app = FastAPI()
+    app.include_router(matching_module.router)
+
+    async def _fake_session() -> Any:
+        yield session
+
+    app.dependency_overrides[matching_module.get_session] = _fake_session
+
+    async def _fake_search(
+        self: Any, *args: Any, **kwargs: Any
+    ) -> dict[str, list[Any]]:
+        return {"results": [_mk_candidate("a")]}
+
+    monkeypatch.setattr(matching_module.ShopSearchService, "search", _fake_search)
+    return TestClient(app)
+
+
+def _load_module(monkeypatch):
+    mod = __import__("app.domains.site.guest_matching", fromlist=["*"])
+    return mod
+
+
+def test_log_phase_step_entry(monkeypatch):
+    matching_module = _load_module(monkeypatch)
+    session = FakeSession()
+    client = _make_client(session, matching_module, monkeypatch)
+
+    resp = client.get(
+        "/api/guest/matching/search",
+        params={
+            "area": "osaka",
+            "date": "2025-01-01",
+            "time_from": "10:00",
+            "time_to": "11:00",
+            "phase": "book",
+            "step_index": 3,
+            "entry_source": "concierge",
+        },
+    )
+    assert resp.status_code == 200
+    # logging is best-effort; ensure it attempted to add one entry
+    assert session.added, "log entry should be added"
+    log = session.added[0]
+    assert log.phase == "book"
+    assert log.step_index == 3
+    assert log.entry_source == "concierge"
+
+
+def test_log_defaults_to_null(monkeypatch):
+    matching_module = _load_module(monkeypatch)
+    session = FakeSession()
+    client = _make_client(session, matching_module, monkeypatch)
+
+    resp = client.get(
+        "/api/guest/matching/search",
+        params={
+            "area": "osaka",
+            "date": "2025-01-01",
+        },
+    )
+    assert resp.status_code == 200
+    assert session.added, "log entry should be added"
+    log = session.added[0]
+    assert log.phase is None
+    assert log.step_index is None
+    assert log.entry_source is None


### PR DESCRIPTION
Add logging fields for matching phase/step_index/entry_source and wire /api/guest/matching/search to persist them per specs.\n\n- GuestMatchLog: add phase, step_index, entry_source + Alembic migration\n- Request model: accept phase/step_index/entry_source (phase normalized)\n- Logging helper: store new fields from search requests (invalid/unspecified -> null)\n- Tests: added logging API test\n\nTests:\n- pytest services/api/app/tests/test_guest_matching_logging.py\n- pre-commit hook ran full backend suite (192 passed, 7 skipped)