### PR TITLE
feat(guest): add guest reservation list

### DIFF
--- a/osakamenesu/apps/web/src/app/guest/reservations/page.tsx
+++ b/osakamenesu/apps/web/src/app/guest/reservations/page.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useEffect, useMemo, useState } from 'react'
+
+type Reservation = {
+  id: string
+  status: string
+  shop_id: string
+  therapist_id: string | null
+  start_at: string
+  end_at: string
+}
+
+export default function GuestReservationsPage() {
+  const [reservations, setReservations] = useState<Reservation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [guestToken, setGuestToken] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const token = window.localStorage.getItem('guest_token')
+    setGuestToken(token)
+  }, [])
+
+  useEffect(() => {
+    const load = async () => {
+      if (!guestToken) {
+        setLoading(false)
+        return
+      }
+      setError(null)
+      try {
+        const resp = await fetch(`/api/guest/reservations?guest_token=${encodeURIComponent(guestToken)}`, {
+          cache: 'no-store',
+        })
+        if (!resp.ok) throw new Error(`status ${resp.status}`)
+        const data = (await resp.json()) as Reservation[]
+        setReservations(data)
+      } catch (e) {
+        console.error('failed to load reservations', e)
+        setError('予約一覧を取得できませんでした。時間をおいて再度お試しください。')
+      } finally {
+        setLoading(false)
+      }
+    }
+    void load()
+  }, [guestToken])
+
+  const rows = useMemo(() => {
+    return reservations.map((r) => {
+      const start = new Date(r.start_at)
+      const end = new Date(r.end_at)
+      const date = start.toLocaleDateString('ja-JP')
+      const startTime = start.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })
+      const endTime = end.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })
+      return { ...r, date, startTime, endTime }
+    })
+  }, [reservations])
+
+  return (
+    <main className="mx-auto max-w-4xl space-y-4 p-4 text-sm">
+      <div>
+        <h1 className="text-2xl font-semibold text-neutral-text">マイ予約一覧</h1>
+        <p className="text-neutral-textMuted">guest_token: {guestToken || '(未発行)'}</p>
+      </div>
+
+      {loading ? <div>読み込み中...</div> : null}
+      {error ? <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-amber-800">{error}</div> : null}
+
+      {!loading && !guestToken ? <div className="text-neutral-textMuted">guest_token が未発行のため予約が表示できません。</div> : null}
+
+      {!loading && guestToken && rows.length === 0 && !error ? (
+        <div className="text-neutral-textMuted">現在予約はありません。</div>
+      ) : null}
+
+      {rows.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full border border-neutral-borderLight text-sm">
+            <thead className="bg-neutral-50 text-left">
+              <tr>
+                <th className="border-b px-3 py-2">日付</th>
+                <th className="border-b px-3 py-2">時間</th>
+                <th className="border-b px-3 py-2">セラピストID</th>
+                <th className="border-b px-3 py-2">ステータス</th>
+                <th className="border-b px-3 py-2">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-b">
+                  <td className="px-3 py-2">{r.date}</td>
+                  <td className="px-3 py-2">{r.startTime} - {r.endTime}</td>
+                  <td className="px-3 py-2">{r.therapist_id ?? '未指定'}</td>
+                  <td className="px-3 py-2">{r.status}</td>
+                  <td className="px-3 py-2">
+                    <a className="text-brand-primary underline" href={`/guest/reservations/${r.id}`}>
+                      詳細を見る
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </main>
+  )
+}

--- a/osakamenesu/apps/web/src/app/guest/therapists/[therapistId]/reserve/page.tsx
+++ b/osakamenesu/apps/web/src/app/guest/therapists/[therapistId]/reserve/page.tsx
@@ -222,6 +222,16 @@ export default function ReservePage({ params }: { params: { therapistId: string 
               <div>
                 日時: {date} {start} - {computedEnd}
               </div>
+              {result.id ? (
+                <a className="text-brand-primary underline" href={`/guest/reservations/${result.id}`}>
+                  予約内容を確認する
+                </a>
+              ) : null}
+              <div>
+                <a className="text-brand-primary underline" href="/guest/reservations">
+                  マイ予約一覧を見る
+                </a>
+              </div>
             </div>
           ) : (
             <div className="space-y-2">

--- a/osakamenesu/apps/web/tests/guest_reservations_list.test.tsx
+++ b/osakamenesu/apps/web/tests/guest_reservations_list.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import GuestReservationsPage from '@/app/guest/reservations/page'
+
+describe('Guest reservations list page', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify([
+          {
+            id: 'r1',
+            status: 'confirmed',
+            shop_id: 'shop-1',
+            therapist_id: 'thera-1',
+            start_at: '2025-01-01T10:00:00Z',
+            end_at: '2025-01-01T11:00:00Z',
+          },
+        ]),
+        { status: 200 },
+      )
+    }) as any
+    // @ts-expect-error partial window mock
+    global.window = {
+      localStorage: {
+        getItem: vi.fn(() => 'guest-token-1'),
+      },
+    }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders reservations from API', async () => {
+    render(<GuestReservationsPage />)
+
+    await waitFor(() => expect(screen.getByText('マイ予約一覧')).toBeInTheDocument())
+    expect(await screen.findByText('thera-1')).toBeInTheDocument()
+    expect(global.fetch).toHaveBeenCalled()
+  })
+
+  it('shows empty message when none', async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify([]), { status: 200 })) as any
+    render(<GuestReservationsPage />)
+    await waitFor(() => expect(screen.getByText('現在予約はありません。')).toBeInTheDocument())
+  })
+})

--- a/osakamenesu/services/api/app/tests/test_guest_reservations_list_api.py
+++ b/osakamenesu/services/api/app/tests/test_guest_reservations_list_api.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.domains.site import guest_reservations as domain
+from app.db import get_session
+
+
+class DummyReservation:
+    def __init__(self, guest_token: str, status: str = "confirmed"):
+        now = datetime.now(timezone.utc)
+        self.id = uuid4()
+        self.status = status
+        self.shop_id = uuid4()
+        self.therapist_id = uuid4()
+        self.start_at = now
+        self.end_at = now
+        self.duration_minutes = 60
+        self.course_id = None
+        self.price = None
+        self.payment_method = None
+        self.contact_info = None
+        self.guest_token = guest_token
+        self.notes = None
+        self.base_staff_id = None
+        self.created_at = now
+        self.updated_at = now
+
+
+class DummySession:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def execute(self, stmt):
+        class R:
+            def __init__(self, values):
+                self.values = values
+
+            def scalars(self):
+                class S:
+                    def __init__(self, values):
+                        self.values = values
+
+                    def all(self):
+                        return self.values
+
+                return S(self.values)
+
+        return R(self.rows)
+
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    return None
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.pop(get_session, None)
+
+
+def test_list_by_guest_token_returns_own_reservations():
+    token = "guest-token-1"
+    r1 = DummyReservation(token)
+    r2 = DummyReservation(token)
+    session = DummySession([r1, r2])
+    app.dependency_overrides[get_session] = lambda: session
+
+    res = client.get("/api/guest/reservations", params={"guest_token": token})
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body) == 2
+    assert all(item["guest_token"] == token for item in body)
+
+
+def test_list_empty_when_no_reservations():
+    token = "no-token"
+    session = DummySession([])
+    app.dependency_overrides[get_session] = lambda: session
+
+    res = client.get("/api/guest/reservations", params={"guest_token": token})
+    assert res.status_code == 200
+    assert res.json() == []


### PR DESCRIPTION
## Summary
- add guest list API GET /api/guest/reservations?guest_token=... (start_at desc)
- add guest-facing /guest/reservations page using localStorage guest_token; links to detail
- show link to list from reserve success

## Testing
- cd services/api && LEFTHOOK=0 pytest app/tests/test_guest_reservations_api.py app/tests/test_guest_reservations_list_api.py -q
- cd apps/web && pnpm test:unit
