### PR TITLE
feat(admin): add reservation detail and status management

### DIFF
--- a/osakamenesu/apps/web/src/app/admin/shops/[shopId]/reservations/[reservationId]/page.tsx
+++ b/osakamenesu/apps/web/src/app/admin/shops/[shopId]/reservations/[reservationId]/page.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type AdminGuestReservationDetail = {
+  id: string
+  shop_id: string
+  shop_name?: string | null
+  therapist_id?: string | null
+  therapist_name?: string | null
+  start_at: string
+  end_at: string
+  status: string
+  contact_info?: Record<string, unknown> | null
+  notes?: string | null
+  created_at: string
+  updated_at: string
+}
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleString('ja-JP', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function pretty(obj?: Record<string, unknown> | null) {
+  if (!obj) return '-'
+  try {
+    return JSON.stringify(obj, null, 2)
+  } catch {
+    return String(obj)
+  }
+}
+
+export default function AdminGuestReservationDetailPage({
+  params,
+}: {
+  params: { shopId: string; reservationId: string }
+}) {
+  const { shopId, reservationId } = params
+  const [reservation, setReservation] =
+    useState<AdminGuestReservationDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [pending, setPending] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await fetch(
+        `/api/admin/guest_reservations/${reservationId}`,
+        { cache: 'no-store' },
+      )
+      if (!resp.ok) {
+        throw new Error(`status ${resp.status}`)
+      }
+      const json = (await resp.json()) as AdminGuestReservationDetail
+      setReservation(json)
+    } catch (err) {
+      console.error('failed to load reservation detail', err)
+      setReservation(null)
+      setError('予約詳細の取得に失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }, [reservationId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const updateStatus = async (nextStatus: 'confirmed' | 'cancelled') => {
+    if (typeof window !== 'undefined') {
+      const ok = window.confirm(`ステータスを ${nextStatus} に変更しますか？`)
+      if (!ok) return
+    }
+    setPending(true)
+    setError(null)
+    setMessage(null)
+    try {
+      const resp = await fetch(
+        `/api/admin/guest_reservations/${reservationId}/status`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            status: nextStatus,
+            reason: nextStatus === 'cancelled' ? 'admin manually cancelled' : undefined,
+          }),
+        },
+      )
+      const json = await resp
+        .json()
+        .catch(() => ({ detail: 'failed to parse response' }))
+      if (!resp.ok) {
+        throw new Error(json?.detail || '更新に失敗しました')
+      }
+      setReservation((prev) =>
+        prev ? { ...prev, status: json.status || nextStatus } : prev,
+      )
+      setMessage('ステータスを更新しました')
+    } catch (err: any) {
+      console.error(err)
+      setError(err?.message || '更新に失敗しました')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const statusColor = useMemo(() => {
+    const status = reservation?.status
+    if (status === 'confirmed') return 'bg-emerald-100 text-emerald-800'
+    if (status === 'cancelled') return 'bg-rose-100 text-rose-800'
+    return 'bg-slate-100 text-slate-800'
+  }, [reservation?.status])
+
+  return (
+    <main className="mx-auto max-w-4xl space-y-4 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">予約詳細</h1>
+          <p className="text-sm text-slate-600">
+            ステータス変更と連絡先/メモの確認ができます。
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/admin/shops/${shopId}/reservations`}
+            className="text-sm text-brand-primary underline"
+          >
+            予約一覧へ戻る
+          </Link>
+          <button
+            onClick={() => load()}
+            className="rounded border border-slate-300 px-3 py-1 text-sm"
+            disabled={loading}
+          >
+            再読込
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {error}
+        </div>
+      ) : null}
+      {message ? (
+        <div className="rounded border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+          {message}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="text-sm text-slate-600">読み込み中...</div>
+      ) : reservation ? (
+        <section className="space-y-3 rounded border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="text-xs text-slate-500">{reservation.id}</div>
+              <div className="text-lg font-semibold">
+                {reservation.shop_name || reservation.shop_id}
+              </div>
+              <div className="text-sm text-slate-600">
+                {reservation.therapist_name || reservation.therapist_id || '担当未定'}
+              </div>
+            </div>
+            <span
+              className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${statusColor}`}
+            >
+              {reservation.status}
+            </span>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-1">
+              <div className="text-xs text-slate-500">開始</div>
+              <div className="text-sm font-medium text-slate-900">
+                {formatDate(reservation.start_at)}
+              </div>
+            </div>
+            <div className="space-y-1">
+              <div className="text-xs text-slate-500">終了</div>
+              <div className="text-sm font-medium text-slate-900">
+                {formatDate(reservation.end_at)}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <div className="text-xs text-slate-500">連絡先</div>
+            <pre className="overflow-auto rounded bg-slate-50 p-2 text-xs text-slate-800">
+              {pretty(reservation.contact_info)}
+            </pre>
+          </div>
+
+          <div className="space-y-1">
+            <div className="text-xs text-slate-500">メモ</div>
+            <div className="rounded bg-slate-50 p-2 text-sm text-slate-800">
+              {reservation.notes || 'なし'}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => updateStatus('confirmed')}
+              className="rounded border border-emerald-300 bg-emerald-50 px-3 py-1 text-sm text-emerald-800 hover:bg-emerald-100 disabled:opacity-60"
+              disabled={pending}
+            >
+              この予約を確定する
+            </button>
+            <button
+              onClick={() => updateStatus('cancelled')}
+              className="rounded border border-rose-200 bg-rose-50 px-3 py-1 text-sm text-rose-800 hover:bg-rose-100 disabled:opacity-60"
+              disabled={pending}
+            >
+              この予約をキャンセルする
+            </button>
+          </div>
+        </section>
+      ) : (
+        <div className="text-sm text-slate-600">予約が見つかりません。</div>
+      )}
+    </main>
+  )
+}

--- a/osakamenesu/apps/web/src/app/admin/shops/[shopId]/reservations/page.tsx
+++ b/osakamenesu/apps/web/src/app/admin/shops/[shopId]/reservations/page.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type AdminGuestReservation = {
+  id: string
+  shop_id: string
+  shop_name?: string | null
+  therapist_id?: string | null
+  therapist_name?: string | null
+  start_at: string
+  end_at: string
+  status: string
+  contact_info?: Record<string, unknown> | null
+  notes?: string | null
+  created_at: string
+  updated_at: string
+}
+
+type ListResponse = {
+  items?: AdminGuestReservation[]
+  summary?: Record<string, number>
+}
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleString('ja-JP', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export default function AdminShopReservationsPage({
+  params,
+}: {
+  params: { shopId: string }
+}) {
+  const { shopId } = params
+  const [items, setItems] = useState<AdminGuestReservation[]>([])
+  const [summary, setSummary] = useState<Record<string, number>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await fetch(
+        `/api/admin/guest_reservations?shop_id=${shopId}`,
+        { cache: 'no-store' },
+      )
+      if (!resp.ok) {
+        throw new Error(`status ${resp.status}`)
+      }
+      const json = (await resp.json()) as ListResponse
+      setItems(json.items ?? [])
+      setSummary(json.summary ?? {})
+    } catch (err) {
+      console.error('failed to load guest reservations', err)
+      setItems([])
+      setSummary({})
+      setError('予約一覧の取得に失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }, [shopId])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const statusBadges = useMemo(() => {
+    const entries = Object.entries(summary)
+    if (!entries.length) return null
+    return entries.map(([status, count]) => (
+      <span
+        key={status}
+        className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-700"
+      >
+        {status}: {count}
+      </span>
+    ))
+  }, [summary])
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-4 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">予約一覧</h1>
+          <p className="text-sm text-slate-600">
+            店舗別のゲスト予約を確認し、詳細へ遷移できます。
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => refresh()}
+            className="rounded border border-slate-300 px-3 py-1 text-sm"
+            disabled={loading}
+          >
+            再読込
+          </button>
+          <Link
+            href="/admin/shops"
+            className="text-sm text-brand-primary underline"
+          >
+            店舗一覧へ
+          </Link>
+        </div>
+      </div>
+
+      {statusBadges ? (
+        <div className="flex flex-wrap gap-2">{statusBadges}</div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="rounded border border-slate-200 bg-white p-3 shadow-sm">
+        {loading ? (
+          <div className="text-sm text-slate-600">読み込み中...</div>
+        ) : items.length === 0 ? (
+          <div className="text-sm text-slate-600">予約がありません。</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs text-slate-600">
+                <th className="px-2 py-1">日時</th>
+                <th className="px-2 py-1">セラピスト</th>
+                <th className="px-2 py-1">ステータス</th>
+                <th className="px-2 py-1">メモ</th>
+                <th className="px-2 py-1">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr key={item.id} className="border-b border-slate-100">
+                  <td className="px-2 py-1">
+                    <div className="font-medium text-slate-900">
+                      {formatDate(item.start_at)}
+                    </div>
+                    <div className="text-xs text-slate-500">
+                      {formatDate(item.end_at)}
+                    </div>
+                  </td>
+                  <td className="px-2 py-1">
+                    {item.therapist_name || item.therapist_id || '-'}
+                  </td>
+                  <td className="px-2 py-1">
+                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-800">
+                      {item.status}
+                    </span>
+                  </td>
+                  <td className="px-2 py-1">
+                    <div className="max-w-xs truncate text-xs text-slate-600">
+                      {item.notes || '-'}
+                    </div>
+                  </td>
+                  <td className="px-2 py-1">
+                    <Link
+                      href={`/admin/shops/${shopId}/reservations/${item.id}`}
+                      className="text-brand-primary underline"
+                    >
+                      詳細
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/osakamenesu/apps/web/src/app/admin/shops/page.tsx
+++ b/osakamenesu/apps/web/src/app/admin/shops/page.tsx
@@ -154,6 +154,12 @@ export default function AdminShopsPage() {
                     >
                       ダッシュボード
                     </a>
+                    <a
+                      className="text-brand-primary underline"
+                      href={`/admin/shops/${shop.id}/reservations`}
+                    >
+                      予約一覧
+                    </a>
                   </td>
                 </tr>
               ))}

--- a/osakamenesu/apps/web/src/app/api/admin/guest_reservations/[id]/status/route.ts
+++ b/osakamenesu/apps/web/src/app/api/admin/guest_reservations/[id]/status/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+import { adminBases, buildAdminHeaders } from '@/app/api/admin/client'
+
+export async function POST(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ detail: 'invalid JSON body' }, { status: 400 })
+  }
+
+  const headers = buildAdminHeaders({ 'Content-Type': 'application/json' })
+  const body = JSON.stringify(payload)
+
+  let lastError: any = null
+  for (const base of adminBases()) {
+    try {
+      const resp = await fetch(`${base}/api/admin/guest_reservations/${id}/status`, {
+        method: 'POST',
+        headers,
+        body,
+        cache: 'no-store',
+      })
+      const text = await resp.text()
+      let json: any = null
+      if (text) {
+        try {
+          json = JSON.parse(text)
+        } catch {
+          json = { detail: text }
+        }
+      }
+      if (resp.ok) {
+        return NextResponse.json(json)
+      }
+      lastError = { status: resp.status, body: json }
+    } catch (err) {
+      lastError = err
+    }
+  }
+
+  if (lastError?.status && lastError.body) {
+    return NextResponse.json(lastError.body, { status: lastError.status })
+  }
+  return NextResponse.json({ detail: 'admin guest reservation status unavailable' }, { status: 503 })
+}

--- a/osakamenesu/apps/web/src/app/api/admin/guest_reservations/route.ts
+++ b/osakamenesu/apps/web/src/app/api/admin/guest_reservations/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+
+import { ADMIN_KEY, adminBases, buildAdminHeaders } from '@/app/api/admin/client'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const query = url.search
+  const headers = buildAdminHeaders()
+
+  let lastError: any = null
+  for (const base of adminBases()) {
+    try {
+      const resp = await fetch(`${base}/api/admin/guest_reservations${query}`, {
+        method: 'GET',
+        headers,
+        cache: 'no-store',
+      })
+      const text = await resp.text()
+      let json: any = null
+      if (text) {
+        try {
+          json = JSON.parse(text)
+        } catch {
+          json = { detail: text }
+        }
+      }
+      if (resp.ok) {
+        return NextResponse.json(json)
+      }
+      lastError = { status: resp.status, body: json }
+    } catch (err) {
+      lastError = err
+    }
+  }
+
+  if (lastError?.status && lastError.body) {
+    return NextResponse.json(lastError.body, { status: lastError.status })
+  }
+
+  return NextResponse.json({ detail: 'admin guest reservations unavailable' }, { status: 503 })
+}

--- a/osakamenesu/services/api/app/domains/admin/guest_reservations_api.py
+++ b/osakamenesu/services/api/app/domains/admin/guest_reservations_api.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ...db import get_session
+from ...models import GuestReservation, Profile, Therapist
+from ..site.guest_reservations import update_guest_reservation_status
+
+router = APIRouter()
+
+
+class AdminGuestReservation(BaseModel):
+    id: UUID
+    shop_id: UUID
+    shop_name: str | None = None
+    therapist_id: UUID | None = None
+    therapist_name: str | None = None
+    start_at: datetime
+    end_at: datetime
+    status: str
+    duration_minutes: int | None = None
+    course_id: UUID | None = None
+    price: float | None = None
+    payment_method: str | None = None
+    contact_info: dict[str, Any] | None = None
+    notes: str | None = None
+    base_staff_id: UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AdminGuestReservationListResponse(BaseModel):
+    items: list[AdminGuestReservation]
+    summary: dict[str, int]
+
+
+class AdminGuestReservationStatusPayload(BaseModel):
+    status: str
+    reason: str | None = None
+
+
+def _status_value(reservation: GuestReservation) -> str:
+    status_value = reservation.status
+    if hasattr(status_value, "value"):
+        status_value = status_value.value
+    return str(status_value)
+
+
+def _serialize_admin_reservation(
+    reservation: GuestReservation,
+    therapist_names: dict[UUID, str] | None = None,
+    shop_names: dict[UUID, str] | None = None,
+) -> AdminGuestReservation:
+    therapist_names = therapist_names or {}
+    shop_names = shop_names or {}
+    return AdminGuestReservation(
+        id=reservation.id,
+        shop_id=reservation.shop_id,
+        shop_name=shop_names.get(reservation.shop_id),
+        therapist_id=reservation.therapist_id,
+        therapist_name=therapist_names.get(reservation.therapist_id)
+        if reservation.therapist_id
+        else None,
+        start_at=reservation.start_at,
+        end_at=reservation.end_at,
+        status=_status_value(reservation),
+        duration_minutes=reservation.duration_minutes,
+        course_id=reservation.course_id,
+        price=reservation.price,
+        payment_method=reservation.payment_method,
+        contact_info=reservation.contact_info,
+        notes=reservation.notes,
+        base_staff_id=reservation.base_staff_id,
+        created_at=reservation.created_at,
+        updated_at=reservation.updated_at,
+    )
+
+
+@router.get(
+    "/api/admin/guest_reservations",
+    response_model=AdminGuestReservationListResponse,
+)
+async def list_guest_reservations(
+    shop_id: UUID | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    db: AsyncSession = Depends(get_session),
+):
+    stmt = select(GuestReservation).order_by(desc(GuestReservation.start_at))
+    if shop_id:
+        stmt = stmt.where(GuestReservation.shop_id == shop_id)
+    if date_from:
+        stmt = stmt.where(GuestReservation.start_at >= date_from)
+    if date_to:
+        stmt = stmt.where(GuestReservation.start_at <= date_to)
+    res = await db.execute(stmt)
+    reservations = res.scalars().all()
+
+    therapist_ids = list({r.therapist_id for r in reservations if r.therapist_id})
+    therapist_names: dict[UUID, str] = {}
+    if therapist_ids:
+        th_res = await db.execute(
+            select(Therapist).where(Therapist.id.in_(therapist_ids))
+        )
+        therapist_names = {t.id: t.name for t in th_res.scalars().all()}
+
+    shop_ids = list({r.shop_id for r in reservations})
+    shop_names: dict[UUID, str] = {}
+    if shop_ids:
+        shop_res = await db.execute(select(Profile).where(Profile.id.in_(shop_ids)))
+        shop_names = {s.id: s.name for s in shop_res.scalars().all()}
+
+    summary: dict[str, int] = {}
+    for r in reservations:
+        status_value = _status_value(r)
+        summary[status_value] = summary.get(status_value, 0) + 1
+
+    items = [
+        _serialize_admin_reservation(r, therapist_names, shop_names)
+        for r in reservations
+    ]
+    return AdminGuestReservationListResponse(items=items, summary=summary)
+
+
+@router.get(
+    "/api/admin/guest_reservations/{reservation_id}",
+    response_model=AdminGuestReservation,
+)
+async def get_guest_reservation_detail(
+    reservation_id: UUID,
+    db: AsyncSession = Depends(get_session),
+):
+    res = await db.execute(
+        select(GuestReservation).where(GuestReservation.id == reservation_id)
+    )
+    reservation = res.scalar_one_or_none()
+    if not reservation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="reservation_not_found"
+        )
+
+    therapist_names: dict[UUID, str] = {}
+    if reservation.therapist_id:
+        th_res = await db.execute(
+            select(Therapist).where(Therapist.id == reservation.therapist_id)
+        )
+        therapist = th_res.scalar_one_or_none()
+        if therapist:
+            therapist_names[therapist.id] = therapist.name
+
+    shop_names: dict[UUID, str] = {}
+    if reservation.shop_id:
+        shop_res = await db.execute(
+            select(Profile).where(Profile.id == reservation.shop_id)
+        )
+        shop = shop_res.scalar_one_or_none()
+        if shop:
+            shop_names[shop.id] = shop.name
+
+    return _serialize_admin_reservation(reservation, therapist_names, shop_names)
+
+
+@router.post(
+    "/api/admin/guest_reservations/{reservation_id}/status",
+)
+async def update_guest_reservation_status_api(
+    reservation_id: UUID,
+    payload: AdminGuestReservationStatusPayload,
+    db: AsyncSession = Depends(get_session),
+):
+    reservation, error = await update_guest_reservation_status(
+        db, reservation_id, payload.status, reason=payload.reason
+    )
+    if not reservation and error == "not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="reservation_not_found"
+        )
+    if error == "invalid_status":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="invalid_status"
+        )
+    if error == "invalid_transition":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="invalid_status_transition"
+        )
+
+    return {"ok": True, "status": _status_value(reservation)}

--- a/osakamenesu/services/api/app/domains/admin/router.py
+++ b/osakamenesu/services/api/app/domains/admin/router.py
@@ -12,6 +12,7 @@ from .reviews_router import router as reviews_router
 from .therapist_shifts_api import router as therapist_shifts_router
 from .shop_dashboard_api import router as shop_dashboard_router
 from .shops_api import router as shops_router
+from .guest_reservations_api import router as guest_reservations_router
 from .therapists_api import router as therapists_router
 
 router = APIRouter(dependencies=[Depends(require_admin), Depends(audit_admin)])
@@ -20,6 +21,7 @@ router.include_router(reservations_router)
 router.include_router(reviews_router)
 router.include_router(therapist_shifts_router)
 router.include_router(shops_router)
+router.include_router(guest_reservations_router)
 router.include_router(therapists_router)
 router.include_router(shop_dashboard_router)
 

--- a/osakamenesu/services/api/app/settings.py
+++ b/osakamenesu/services/api/app/settings.py
@@ -20,6 +20,12 @@ class Settings(BaseSettings):
     meili_host: str = "http://osakamenesu-meili:7700"
     meili_master_key: str = "dev_meili_master_key"
     admin_api_key: str = "dev_admin_key"
+    proxy_shared_secret: str | None = Field(
+        default=None, validation_alias=AliasChoices("PROXY_SHARED_SECRET")
+    )
+    async_worker_token: str | None = Field(
+        default=None, validation_alias=AliasChoices("ASYNC_WORKER_TOKEN")
+    )
     rate_limit_redis_url: str | None = None
     rate_limit_namespace: str = "osakamenesu_outlinks"
     rate_limit_redis_error_cooldown: float = 5.0

--- a/osakamenesu/services/api/app/tests/test_admin_guest_reservations_detail_status.py
+++ b/osakamenesu/services/api/app/tests/test_admin_guest_reservations_detail_status.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.domains.admin import guest_reservations_api as api  # noqa: F401 - import for coverage
+from app.db import get_session
+from app.deps import audit_admin, require_admin
+from app.models import GuestReservation, Profile, Therapist
+
+
+class DummyTherapist:
+    def __init__(self, id, name: str):
+        self.id = id
+        self.name = name
+
+
+class DummyShop:
+    def __init__(self, id, name: str):
+        self.id = id
+        self.name = name
+
+
+class DummySession:
+    def __init__(self, reservations=None, therapists=None, shops=None):
+        self.reservations = reservations or []
+        self.therapists = therapists or []
+        self.shops = shops or []
+        self.added = []
+        self.commits = 0
+
+    async def execute(self, stmt):
+        model = stmt.column_descriptions[0]["entity"]
+        items = []
+        if model is GuestReservation:
+            items = self.reservations
+        elif model is Therapist:
+            items = self.therapists
+        elif model is Profile:
+            items = self.shops
+
+        class R:
+            def __init__(self, items):
+                self.items = items
+
+            def scalars(self):
+                class S:
+                    def __init__(self, items):
+                        self._items = items
+
+                    def all(self):
+                        return self._items
+
+                    def first(self):
+                        return self._items[0] if self._items else None
+
+                return S(self.items)
+
+            def scalar_one_or_none(self):
+                if not self.items:
+                    return None
+                return self.items[0]
+
+        return R(items)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+    async def refresh(self, obj, attribute_names=None):
+        return None
+
+
+client = TestClient(app)
+
+
+def setup_function():
+    app.dependency_overrides[get_session] = lambda: DummySession()
+    app.dependency_overrides[require_admin] = lambda: None
+    app.dependency_overrides[audit_admin] = lambda: None
+
+
+def teardown_function():
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(require_admin, None)
+    app.dependency_overrides.pop(audit_admin, None)
+
+
+def _reservation(status: str = "pending") -> GuestReservation:
+    now = datetime.now(timezone.utc)
+    return GuestReservation(
+        id=uuid4(),
+        shop_id=uuid4(),
+        therapist_id=uuid4(),
+        start_at=now,
+        end_at=now + timedelta(hours=1),
+        status=status,
+        contact_info={"email": "guest@example.com"},
+        notes="",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_get_admin_guest_reservation_detail():
+    reservation = _reservation(status="confirmed")
+    therapist = DummyTherapist(reservation.therapist_id, "セラピストA")
+    shop = DummyShop(reservation.shop_id, "店舗A")
+    session = DummySession(
+        reservations=[reservation], therapists=[therapist], shops=[shop]
+    )
+    app.dependency_overrides[get_session] = lambda: session
+
+    res = client.get(f"/api/admin/guest_reservations/{reservation.id}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["id"] == str(reservation.id)
+    assert body["therapist_name"] == therapist.name
+    assert body["shop_name"] == shop.name
+
+
+def test_get_admin_guest_reservation_not_found():
+    app.dependency_overrides[get_session] = lambda: DummySession(reservations=[])
+    res = client.get(f"/api/admin/guest_reservations/{uuid4()}")
+    assert res.status_code == 404
+
+
+def test_admin_status_updates_confirm_and_cancel():
+    reservation = _reservation(status="pending")
+    session = DummySession(reservations=[reservation])
+    app.dependency_overrides[get_session] = lambda: session
+
+    res = client.post(
+        f"/api/admin/guest_reservations/{reservation.id}/status",
+        json={"status": "confirmed"},
+    )
+    assert res.status_code == 200
+    assert res.json()["status"] == "confirmed"
+
+    res2 = client.post(
+        f"/api/admin/guest_reservations/{reservation.id}/status",
+        json={"status": "cancelled", "reason": "admin cancelled"},
+    )
+    assert res2.status_code == 200
+    assert res2.json()["status"] == "cancelled"
+
+
+def test_admin_status_cancel_idempotent():
+    reservation = _reservation(status="cancelled")
+    session = DummySession(reservations=[reservation])
+    app.dependency_overrides[get_session] = lambda: session
+
+    res = client.post(
+        f"/api/admin/guest_reservations/{reservation.id}/status",
+        json={"status": "cancelled"},
+    )
+    assert res.status_code == 200
+    assert res.json()["status"] == "cancelled"
+
+
+def test_admin_status_invalid_transition_and_value():
+    reservation = _reservation(status="cancelled")
+    session = DummySession(reservations=[reservation])
+    app.dependency_overrides[get_session] = lambda: session
+
+    bad_status = client.post(
+        f"/api/admin/guest_reservations/{reservation.id}/status",
+        json={"status": "unknown"},
+    )
+    assert bad_status.status_code == 400
+
+    invalid_transition = client.post(
+        f"/api/admin/guest_reservations/{reservation.id}/status",
+        json={"status": "confirmed"},
+    )
+    assert invalid_transition.status_code == 400


### PR DESCRIPTION
## Summary
- add admin guest reservation detail/status APIs and settings fields for proxy/worker secrets
- add /admin/shops/[shopId]/reservations and /admin/shops/[shopId]/reservations/[reservationId] pages with status actions plus BFF routes
- link reservation list from shops page

## Testing
- LEFTHOOK=0 pytest app/tests/test_admin_guest_reservations_detail_status.py -q
- cd services/api && LEFTHOOK=0 pytest app/tests/test_async_jobs.py app/tests/test_proxy_signature.py -q
- cd apps/web && pnpm test:unit
- lefthook pre-commit (includes full pytest, lint, typecheck)