### PR TITLE
chore(spec): align shifts & reservations core with Speckit

### DIFF
--- a/osakamenesu/.specify/specs/shifts/core/spec.md
+++ b/osakamenesu/.specify/specs/shifts/core/spec.md
@@ -35,14 +35,16 @@
 - 空き枠計算: シフト時間帯 － 休憩 － 確定済み予約(GuestReservation) の差分を計算。
 - 判定API/関数:
   - `is_available(therapist_id, start_at, end_at)`
-    - 完全に内包する "available" シフトがあること
+    - 完全に内包する "available" シフトがあること（半開区間で判定）
     - 休憩と重ならないこと
-    - 同一セラの confirmed/pending 予約と重複しないこと
-    - fail-soft: 異常があっても例外にせず (False, reasons) を返す
+    - 同一セラの pending/confirmed 予約と重複しないこと（start < other.end && other.start < end）
+    - cancelled 予約はブロックに含めない。fail-soft: 異常があっても例外にせず (False, reasons) を返す。
+    - バッファ/移動時間は v1 では未実装（TODO）
   - `list_daily_slots(therapist_id, date)` (簡易版で可)
     - v1 は status を "free"/"closed" 程度に留め、細かい閾値は TODO
 - 直前予約の締切: 予約コアの締切ルール（例: 開始60分前まで）と整合。締切超過は "closed" 扱い。
 - 重複判定: シフト自体も同一セラで重複登録不可。予約との重複は空き枠計算時に除外。
+ - 予約作成/更新時は is_available を内部で呼び、シフト外や重複があれば rejected_reasons を返す前提。
 
 ## 4. 具体例
 - ケース1: 通常シフト + 休憩 + 予約あり

--- a/osakamenesu/services/api/app/tests/test_shifts_reservations_integration.py
+++ b/osakamenesu/services/api/app/tests/test_shifts_reservations_integration.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.domains.site import guest_reservations as domain
+from app.domains.site.guest_reservations import (
+    cancel_guest_reservation,
+    create_guest_reservation,
+)
+from app.models import GuestReservation
+
+
+def _ts(hour: int, minute: int = 0) -> datetime:
+    return datetime(2025, 1, 1, hour, minute, tzinfo=timezone.utc)
+
+
+class DummyResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+
+class DummySession:
+    def __init__(self):
+        self.reservations: list[GuestReservation] = []
+
+    async def execute(self, stmt):
+        entity = stmt.column_descriptions[0]["entity"]
+        if entity is GuestReservation:
+            lookup_id = None
+            try:
+                crit = list(getattr(stmt, "_where_criteria", []))
+                if crit:
+                    right = getattr(crit[0], "right", None)
+                    lookup_id = getattr(right, "value", None)
+            except Exception:
+                lookup_id = None
+            if lookup_id:
+                found = next(
+                    (r for r in self.reservations if str(r.id) == str(lookup_id)), None
+                )
+                return DummyResult(found)
+            return DummyResult(None)
+        return DummyResult(None)
+
+    def add(self, obj):
+        if isinstance(obj, GuestReservation):
+            # replace existing with same id or append
+            self.reservations = [
+                r for r in self.reservations if str(r.id) != str(obj.id)
+            ] + [obj]
+
+    async def commit(self):
+        return None
+
+    async def refresh(self, obj, attribute_names=None):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_create_cancel_and_recreate(monkeypatch: pytest.MonkeyPatch):
+    session = DummySession()
+    therapist_id = uuid4()
+    shift_start = _ts(9)
+    shift_end = _ts(18)
+
+    def _overlaps(
+        a_start: datetime, a_end: datetime, b_start: datetime, b_end: datetime
+    ) -> bool:
+        return a_start < b_end and b_start < a_end
+
+    async def fake_is_available(db, tid, start_at, end_at):
+        if str(tid) != str(therapist_id):
+            return False, {"rejected_reasons": ["no_shift"]}
+        if not (shift_start <= start_at and end_at <= shift_end):
+            return False, {"rejected_reasons": ["no_shift"]}
+        for res in session.reservations:
+            if str(res.therapist_id) != str(therapist_id):
+                continue
+            if str(res.status) in ("pending", "confirmed") and _overlaps(
+                start_at, end_at, res.start_at, res.end_at
+            ):
+                return False, {"rejected_reasons": ["overlap_existing_reservation"]}
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "is_available", fake_is_available)
+
+    payload = {
+        "shop_id": uuid4(),
+        "therapist_id": therapist_id,
+        "start_at": _ts(10),
+        "end_at": _ts(11),
+    }
+
+    res, debug = await create_guest_reservation(session, payload, now=_ts(8))
+    assert res is not None
+    assert str(res.status) == "confirmed"
+    assert debug == {}
+    assert len(session.reservations) == 1
+
+    overlap_payload = {
+        "shop_id": uuid4(),
+        "therapist_id": therapist_id,
+        "start_at": _ts(10, 30),
+        "end_at": _ts(11, 30),
+    }
+    res2, debug2 = await create_guest_reservation(session, overlap_payload, now=_ts(8))
+    assert res2 is None
+    assert "overlap_existing_reservation" in debug2.get("rejected_reasons", [])
+
+    cancelled = await cancel_guest_reservation(session, res.id, reason="user_cancelled")
+    assert cancelled and str(cancelled.status) == "cancelled"
+
+    res3, debug3 = await create_guest_reservation(session, overlap_payload, now=_ts(8))
+    assert res3 is not None
+    assert debug3 == {}
+    assert str(res3.status) == "confirmed"

--- a/osakamenesu/specs/reservations/core.yaml
+++ b/osakamenesu/specs/reservations/core.yaml
@@ -83,8 +83,13 @@ flow:
   statuses: |
     create -> pending or confirmed (v1 may auto-confirm).
     pending/confirmed -> cancelled when cancelled by guest/staff/admin.
+    cancelled reservations release the slot and should not block availability.
   stock_check: |
     v1: reject exact duplicate slot for the same therapist_id.
-    Advanced shift/inventory logic is out of scope for v1.
+    Overlap is defined as start_at < other.end_at AND other.start_at < end_at (half-open interval).
+    Pending/confirmed reservations block the slot; cancelled does not.
+    Reservations must be fully inside an available therapist shift; otherwise reject with no_shift/on_break.
+    Buffer minutes between reservations/shifts are out of scope for v1 (TODO).
   scope_notes: |
     Payments, notifications, and approval workflows are out-of-scope for v1 and can be added later.
+    If a shift is missing or marked unavailable, treat the slot as closed.


### PR DESCRIPTION
## Summary
- clarify reservations.core: shift-required, half-open overlap, pending/confirmed block, cancelled frees capacity; buffer left TODO
- update shifts core spec to define is_available expectations (in-shift, no break overlap, pending/confirmed reservations block, cancelled ignored), buffer/free-few-full marked TBD
- add integration test for shifts x reservations: allows booking in-shift, rejects overlap, cancel frees slot

## Testing
- cd services/api && LEFTHOOK=0 pytest app/tests/test_shifts_reservations_integration.py -q
