### PR TITLE
feat(matching): implement recommended score

### DIFF
--- a/osakamenesu/package.json
+++ b/osakamenesu/package.json
@@ -19,7 +19,8 @@
     "ci:local": "doppler run --project osakamenesu --config stg_ci_local -- bash -c 'export COMPOSE_PLATFORM=linux/amd64; docker compose --env-file .env.admin-e2e -f docker-compose.admin-e2e.yml -f docker-compose.admin-e2e.override.yml up -d db meili redis api web && export COMPOSE_PLATFORM=linux/amd64; docker compose --env-file .env.admin-e2e -f docker-compose.admin-e2e.yml -f docker-compose.admin-e2e.override.yml up --no-deps --abort-on-container-exit --exit-code-from e2e --no-build e2e'"
   },
   "devDependencies": {
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "vitest": "^4.0.14"
   },
   "packageManager": "pnpm@10.20.0"
 }

--- a/osakamenesu/pnpm-lock.yaml
+++ b/osakamenesu/pnpm-lock.yaml
@@ -11,8 +11,321 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      vitest:
+        specifier: ^4.0.14
+        version: 4.0.14
 
 packages:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.53.3':
+    resolution: {integrity: sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.53.3':
+    resolution: {integrity: sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.53.3':
+    resolution: {integrity: sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.53.3':
+    resolution: {integrity: sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.53.3':
+    resolution: {integrity: sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.53.3':
+    resolution: {integrity: sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
+    resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
+    resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.53.3':
+    resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.53.3':
+    resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.53.3':
+    resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
+    resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
+    resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.53.3':
+    resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.53.3':
+    resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.53.3':
+    resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.53.3':
+    resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.53.3':
+    resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.53.3':
+    resolution: {integrity: sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.53.3':
+    resolution: {integrity: sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.53.3':
+    resolution: {integrity: sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.53.3':
+    resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitest/expect@4.0.14':
+    resolution: {integrity: sha512-RHk63V3zvRiYOWAV0rGEBRO820ce17hz7cI2kDmEdfQsBjT2luEKB5tCOc91u1oSQoUOZkSv3ZyzkdkSLD7lKw==}
+
+  '@vitest/mocker@4.0.14':
+    resolution: {integrity: sha512-RzS5NujlCzeRPF1MK7MXLiEFpkIXeMdQ+rN3Kk3tDI9j0mtbr7Nmuq67tpkOJQpgyClbOltCXMjLZicJHsH5Cg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.14':
+    resolution: {integrity: sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==}
+
+  '@vitest/runner@4.0.14':
+    resolution: {integrity: sha512-BsAIk3FAqxICqREbX8SetIteT8PiaUL/tgJjmhxJhCsigmzzH8xeadtp7LRnTpCVzvf0ib9BgAfKJHuhNllKLw==}
+
+  '@vitest/snapshot@4.0.14':
+    resolution: {integrity: sha512-aQVBfT1PMzDSA16Y3Fp45a0q8nKexx6N5Amw3MX55BeTeZpoC08fGqEZqVmPcqN0ueZsuUQ9rriPMhZ3Mu19Ag==}
+
+  '@vitest/spy@4.0.14':
+    resolution: {integrity: sha512-JmAZT1UtZooO0tpY3GRyiC/8W7dCs05UOq9rfsUUgEZEdq+DuHLmWhPsrTt0TiW7WYeL/hXpaE07AZ2RCk44hg==}
+
+  '@vitest/utils@4.0.14':
+    resolution: {integrity: sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -25,6 +338,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -51,6 +368,10 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  chai@6.2.1:
+    resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -108,6 +429,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -120,13 +444,39 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -303,6 +653,9 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -313,6 +666,11 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -337,6 +695,9 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -356,6 +717,16 @@ packages:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
     engines: {node: '>=4'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
   pidtree@0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
     engines: {node: '>=0.10'}
@@ -368,6 +739,10 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   read-pkg@3.0.0:
     resolution: {integrity: sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==}
@@ -384,6 +759,11 @@ packages:
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
+    hasBin: true
+
+  rollup@4.53.3:
+    resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   safe-array-concat@1.1.3:
@@ -442,6 +822,13 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -453,6 +840,12 @@ packages:
 
   spdx-license-ids@3.0.22:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -486,6 +879,20 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -509,6 +916,80 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite@7.2.4:
+    resolution: {integrity: sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.14:
+    resolution: {integrity: sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.14
+      '@vitest/browser-preview': 4.0.14
+      '@vitest/browser-webdriverio': 4.0.14
+      '@vitest/ui': 4.0.14
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -529,7 +1010,208 @@ packages:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
 snapshots:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.53.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.53.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.53.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.53.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.53.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.53.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.53.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.53.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.53.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.53.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.53.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.53.3':
+    optional: true
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/expect@4.0.14':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.14
+      '@vitest/utils': 4.0.14
+      chai: 6.2.1
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.14(vite@7.2.4)':
+    dependencies:
+      '@vitest/spy': 4.0.14
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.4
+
+  '@vitest/pretty-format@4.0.14':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.14':
+    dependencies:
+      '@vitest/utils': 4.0.14
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.14':
+    dependencies:
+      '@vitest/pretty-format': 4.0.14
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.14': {}
+
+  '@vitest/utils@4.0.14':
+    dependencies:
+      '@vitest/pretty-format': 4.0.14
+      tinyrainbow: 3.0.3
 
   ansi-styles@3.2.1:
     dependencies:
@@ -549,6 +1231,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
 
@@ -579,6 +1263,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  chai@6.2.1: {}
 
   chalk@2.4.2:
     dependencies:
@@ -703,6 +1389,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -720,11 +1408,53 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   escape-string-regexp@1.0.5: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.2.2: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -919,6 +1649,10 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   memorystream@0.3.1: {}
@@ -926,6 +1660,8 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
+
+  nanoid@3.3.11: {}
 
   nice-try@1.0.5: {}
 
@@ -961,6 +1697,8 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
+  obug@2.1.1: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -980,11 +1718,23 @@ snapshots:
     dependencies:
       pify: 3.0.0
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
   pidtree@0.3.1: {}
 
   pify@3.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   read-pkg@3.0.0:
     dependencies:
@@ -1017,6 +1767,34 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rollup@4.53.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.53.3
+      '@rollup/rollup-android-arm64': 4.53.3
+      '@rollup/rollup-darwin-arm64': 4.53.3
+      '@rollup/rollup-darwin-x64': 4.53.3
+      '@rollup/rollup-freebsd-arm64': 4.53.3
+      '@rollup/rollup-freebsd-x64': 4.53.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.53.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.53.3
+      '@rollup/rollup-linux-arm64-gnu': 4.53.3
+      '@rollup/rollup-linux-arm64-musl': 4.53.3
+      '@rollup/rollup-linux-loong64-gnu': 4.53.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.53.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.53.3
+      '@rollup/rollup-linux-riscv64-musl': 4.53.3
+      '@rollup/rollup-linux-s390x-gnu': 4.53.3
+      '@rollup/rollup-linux-x64-gnu': 4.53.3
+      '@rollup/rollup-linux-x64-musl': 4.53.3
+      '@rollup/rollup-openharmony-arm64': 4.53.3
+      '@rollup/rollup-win32-arm64-msvc': 4.53.3
+      '@rollup/rollup-win32-ia32-msvc': 4.53.3
+      '@rollup/rollup-win32-x64-gnu': 4.53.3
+      '@rollup/rollup-win32-x64-msvc': 4.53.3
+      fsevents: 2.3.3
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -1097,6 +1875,10 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -1110,6 +1892,10 @@ snapshots:
       spdx-license-ids: 3.0.22
 
   spdx-license-ids@3.0.22: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -1153,6 +1939,17 @@ snapshots:
       has-flag: 3.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -1199,6 +1996,52 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  vite@7.2.4:
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.53.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.0.14:
+    dependencies:
+      '@vitest/expect': 4.0.14
+      '@vitest/mocker': 4.0.14(vite@7.2.4)
+      '@vitest/pretty-format': 4.0.14
+      '@vitest/runner': 4.0.14
+      '@vitest/snapshot': 4.0.14
+      '@vitest/spy': 4.0.14
+      '@vitest/utils': 4.0.14
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.4
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -1243,3 +2086,8 @@ snapshots:
   which@1.3.1:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/osakamenesu/specs/matching/recommended_score/spec.md
+++ b/osakamenesu/specs/matching/recommended_score/spec.md
@@ -1,0 +1,446 @@
+# matching/recommended_score
+
+`sort=recommended` のときに使用する、セラピスト推薦スコアの算出ロジック。
+
+1人のゲスト（検索者）の `GuestIntent` と、1人のセラピストの `TherapistProfile` から
+`recommended_score: number`（0〜1.05程度）を計算し、その降順で並び替える。
+
+## 目的
+
+- ゲストにとって
+  - 顔・雰囲気・会話スタイル・施術の強さなどの「好み」に近いセラピストが上位に出ること
+- セラピストにとって
+  - 特定の人気セラピストだけに予約が集中しすぎず、自分にもチャンスが回ってくること
+- 店舗にとって
+  - 新人〜中堅が自然に育ちつつ、全体の稼働バランス・売上が最適化されること
+
+この3者（ゲスト・セラピスト・店舗）の Win-Win-Win を目指す。
+
+---
+
+## 入力定義
+
+### GuestIntent
+
+コンシェルジュや検索UIから組み立てられる「ゲストの希望」。
+
+```ts
+type ConversationStyle = "talkative" | "normal" | "quiet";
+type MassagePressure = "soft" | "medium" | "strong";
+type MoodTag =
+  | "cheerful"      // 明るく元気
+  | "calm"          // 落ち着いてしっとり
+  | "healing"       // ふんわり癒し
+  | "oneesan_mood"  // 甘やかし・お姉さんぽい
+  | "playful";      // フレンドリー・距離近め
+
+type VisualStyleTag =
+  | "baby_face"     // 小動物系・童顔かわいい
+  | "kawaii"        // 王道かわいい
+  | "natural"       // 素朴・ナチュラル
+  | "oneesan"       // 大人っぽい・お姉さん系
+  | "cool_beauty"   // クールビューティ
+  | "gal"           // ギャル・派手め
+  | "elegant";      // 清楚・きれい系
+
+type GuestIntent = {
+  area: string | null;          // エリア（"namba"など）
+  date: string | null;          // YYYY-MM-DD
+  time_from: string | null;     // HH:MM
+  time_to: string | null;       // HH:MM
+  price_min: number | null;
+  price_max: number | null;
+  shop_id: string | null;
+
+  // 顔・見た目の好み（0〜2個）
+  visual_style_tags: VisualStyleTag[];
+
+  // スタイル系の好み
+  conversation_preference: ConversationStyle | null;   // 会話量
+  massage_pressure_preference: MassagePressure | null; // 圧
+  mood_preference_tags: MoodTag[];                    // 雰囲気（0〜2個）
+
+  raw_text: string; // 自然文（ログ・将来の学習用）
+};
+```
+
+### TherapistProfile（スコア計算で使う部分）
+
+```ts
+type TherapistProfile = {
+  therapist_id: string;
+
+  // 顔タイプ（0〜2個）
+  visual_style_tags: VisualStyleTag[];
+
+  // スタイル
+  conversation_style: ConversationStyle;  // メインの会話スタイル
+  massage_pressure: MassagePressure;      // ベースの圧
+  mood_tags: MoodTag[];                   // 雰囲気（0〜3個）
+
+  // 人気・実績系（事前に集計済み）
+  total_bookings_30d: number;   // 過去30日予約数
+  repeat_rate_30d: number;      // 過去30日リピート率(0〜1)
+  avg_review_score: number;     // レビュー平均(1〜5等)
+  price_tier: number;           // 単価帯（例: 1=低, 2=中, 3=高）
+
+  // 新人 / 稼働状況
+  days_since_first_shift: number; // デビューからの日数
+  utilization_7d: number;         // 直近7日: 予約枠/シフト枠 (0〜1)
+
+  // 希望時間帯における入りやすさ（別ロジックで算出済み）
+  availability_score: number;     // 0〜1
+};
+```
+
+## スコアの構造
+
+`recommended_score` は次の3レイヤーで構成する。
+
+- `affinity_score`: 顔の系統＋スタイル（会話・雰囲気・圧）の相性
+- `user_fit_score` / `fairness_score`:
+  - `user_fit` = 相性 + 人気
+  - `fairness` = 新人ブースト + 稼働バランス
+  を重みづけして合成
+- `availability_factor`: 希望時間帯にどれくらい入りやすいか（0.9〜1.05）
+
+最終的な式：
+
+```
+base = 0.8 * user_fit_score + 0.2 * fairness_score; // 0〜1 前後
+recommended_score = clamp01(base) * availability_factor; // 0〜およそ1.05
+```
+
+`sort=recommended` のときは、この `recommended_score` の降順で並べる。
+
+## コンポーネント詳細
+
+### 1. 顔の相性: look_match_score (0〜1)
+
+GuestIntent と TherapistProfile の visual_style_tags の一致度。
+
+```ts
+function computeFaceTagMatchScore(
+  userTags: VisualStyleTag[],
+  therapistTags: VisualStyleTag[],
+): number {
+  // どちらか未設定なら顔の好みではプラスマイナスしない → 中立
+  if (userTags.length === 0 || therapistTags.length === 0) {
+    return 0.5;
+  }
+
+  const setUser = new Set(userTags);
+  const setTherapist = new Set(therapistTags);
+
+  let intersectionCount = 0;
+  for (const tag of setUser) {
+    if (setTherapist.has(tag)) intersectionCount++;
+  }
+
+  const maxPossible = Math.min(setUser.size, setTherapist.size);
+  if (maxPossible === 0) return 0.0; // 完全不一致
+
+  const raw = intersectionCount / maxPossible; // 0〜1
+  return raw;
+}
+```
+
+- 1個一致：0.5〜1.0
+- 2個一致：1.0
+- 完全不一致：0.0
+- どちらか未設定：0.5（中立）
+
+look_match_score としてこの値を用いる。
+
+### 2. スタイル相性: style_match_score (0〜1)
+
+会話・圧・雰囲気の3つを合成する。
+
+```ts
+// 会話量
+function conversationMatchScore(
+  pref: ConversationStyle | null,
+  actual: ConversationStyle,
+): number {
+  if (!pref) return 0.5;
+
+  if (pref === actual) return 1.0;
+
+  // normal ↔ talkative / quiet はそこそこOK
+  if (
+    (pref === "talkative" && actual === "normal") ||
+    (pref === "normal"     && actual === "talkative") ||
+    (pref === "quiet"      && actual === "normal") ||
+    (pref === "normal"     && actual === "quiet")
+  ) {
+    return 0.7;
+  }
+
+  // talkative vs quiet のような真逆
+  return 0.3;
+}
+
+// 圧
+function pressureMatchScore(
+  pref: MassagePressure | null,
+  actual: MassagePressure,
+): number {
+  if (!pref) return 0.5;
+
+  if (pref === actual) return 1.0;
+
+  // medium を挟む組み合わせは許容
+  if (
+    (pref === "soft"   && actual === "medium") ||
+    (pref === "medium" && actual === "soft")   ||
+    (pref === "medium" && actual === "strong") ||
+    (pref === "strong" && actual === "medium")
+  ) {
+    return 0.7;
+  }
+
+  // soft vs strong
+  return 0.3;
+}
+
+// 雰囲気
+function moodMatchScore(
+  prefTags: MoodTag[],
+  actualTags: MoodTag[],
+): number {
+  if (prefTags.length === 0 || actualTags.length === 0) {
+    return 0.5; // 中立
+  }
+
+  const prefSet = new Set(prefTags);
+  const actSet = new Set(actualTags);
+
+  let intersection = 0;
+  for (const t of prefSet) {
+    if (actSet.has(t)) intersection++;
+  }
+
+  const maxPossible = Math.min(prefSet.size, actSet.size);
+  if (maxPossible === 0) return 0.3; // 完全不一致 → やや低め
+
+  const raw = intersection / maxPossible; // 0〜1
+  return 0.3 + 0.7 * raw;                // 0.3〜1.0 にマッピング
+}
+```
+
+合成：
+
+```ts
+function styleMatchScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const conv  = conversationMatchScore(intent.conversation_preference, profile.conversation_style);
+  const press = pressureMatchScore(intent.massage_pressure_preference, profile.massage_pressure);
+  const mood  = moodMatchScore(intent.mood_preference_tags, profile.mood_tags);
+
+  const w_conv  = 0.4;
+  const w_press = 0.3;
+  const w_mood  = 0.3;
+
+  return w_conv * conv + w_press * press + w_mood * mood; // 0〜1
+}
+```
+
+### 3. affinity_score (0〜1)
+
+顔とスタイルの相性。
+
+```ts
+function affinityScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const look  = computeFaceTagMatchScore(intent.visual_style_tags, profile.visual_style_tags);
+  const style = styleMatchScore(intent, profile);
+
+  const w_look  = 0.5;
+  const w_style = 0.5;
+
+  return w_look * look + w_style * style; // 0〜1
+}
+```
+
+### 4. popularity_score (0〜1)
+
+人気・実績。強くしすぎると人気偏重になるため、軽め＆圧縮する。
+
+```ts
+function popularityScore(profile: TherapistProfile): number {
+  // それぞれ 0〜1 に正規化済みと仮定する
+  const b    = normalizeBookings(profile.total_bookings_30d); // 0〜1
+  const r    = clamp01(profile.repeat_rate_30d);              // 0〜1
+  const rev  = normalizeReview(profile.avg_review_score);     // 0〜1
+  const tier = normalizePriceTier(profile.price_tier);        // 0〜1（高単価なら少し加点）
+
+  const raw =
+    0.4 * b +
+    0.3 * r +
+    0.2 * rev +
+    0.1 * tier;
+
+  // 上位人気の差を緩めるために sqrt で圧縮
+  return Math.sqrt(clamp01(raw)); // 0〜1
+}
+```
+
+`normalizeBookings` / `normalizeReview` / `normalizePriceTier` は別途実装（ロジックはこの spec では詳細に縛らないが、0〜1に収まること）。
+
+### 5. newcomer_score (0〜1)
+
+新人・中堅へのブースト。
+
+```ts
+function newcomerScore(daysSinceFirstShift: number): number {
+  if (daysSinceFirstShift <= 7)  return 0.9; // デビュー1週間
+  if (daysSinceFirstShift <= 30) return 0.6; // 〜1ヶ月
+  if (daysSinceFirstShift <= 90) return 0.3; // 〜3ヶ月
+  return 0.1;                                // それ以降
+}
+```
+
+### 6. load_balance_score (0〜1)
+
+直近の稼働バランス。忙しすぎる子は下がり、暇な子は上がる。
+
+```ts
+// utilization_7d: 直近7日の「予約済み枠 / シフト枠」(0〜1)
+function loadBalanceScore(utilization_7d: number): number {
+  const u = clamp01(utilization_7d);
+  return 1.0 - u; // 0〜1
+}
+```
+
+### 7. fairness_score (0〜1)
+
+新規・中堅ブースト＋稼働の偏り防止。
+
+```ts
+function fairnessScore(profile: TherapistProfile): number {
+  const newcomer = newcomerScore(profile.days_since_first_shift);
+  const load     = loadBalanceScore(profile.utilization_7d);
+
+  const w_newcomer = 0.5;
+  const w_load     = 0.5;
+
+  return w_newcomer * newcomer + w_load * load; // 0〜1
+}
+```
+
+### 8. availability_factor (0.9〜1.05)
+
+「希望時間にどれくらい入りやすいか」を少しだけ反映する係数。
+相性や人気をねじ曲げない範囲（±10%以内）に収める。
+
+```ts
+function availabilityFactor(availability_score: number): number {
+  const a = clamp01(availability_score);
+  const minFactor = 0.9;
+  const maxFactor = 1.05;
+
+  return minFactor + (maxFactor - minFactor) * a; // 0.9〜1.05
+}
+```
+
+### 9. user_fit_score (0〜1)
+
+お客側視点の「合いそう度」。
+相性を重視しつつ、人気も少し見る。
+
+```ts
+function userFitScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const affinity   = affinityScore(intent, profile);  // 0〜1
+  const popularity = popularityScore(profile);        // 0〜1
+
+  const w_affinity   = 0.7;
+  const w_popularity = 0.3;
+
+  return w_affinity * affinity + w_popularity * popularity;
+}
+```
+
+### 最終スコア：recommended_score
+
+```ts
+export function recommendedScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const user_fit = userFitScore(intent, profile);   // 0〜1
+  const fair     = fairnessScore(profile);          // 0〜1
+  const availFac = availabilityFactor(profile.availability_score); // 0.9〜1.05
+
+  const w_user = 0.8;
+  const w_fair = 0.2;
+
+  const base = w_user * user_fit + w_fair * fair;   // 0〜1 前後
+  const clampedBase = clamp01(base);
+
+  return clampedBase * availFac; // 0〜およそ1.05
+}
+```
+
+`clamp01(x)` は 0 <= x <= 1 に収めるユーティリティ。
+
+---
+
+## テスト観点（必須）
+
+`recommendedScore` には少なくとも以下のようなテストケースを用意すること：
+
+1. 人気＆相性が高いベテラン vs 相性ドンピシャな新人
+
+- Case A: affinity=高, popularity=高, days_since_first_shift 大, utilization_7d=高
+- Case B: affinity=非常に高い, popularity=低, days_since_first_shift 小, utilization_7d=低
+- → B の方が recommended_score が同等以上になること（新人にちゃんとチャンスが回る）。
+
+2. 人気だけ高くて相性が低いセラピスト
+
+- 相性が低いが、人気系メトリクスだけ高いプロファイル
+- 相性が高く職歴が浅いセラピストよりも上位に来ないこと。
+
+3. availability_score の影響
+
+- 同一の user_fit / fairness を持つ2人で、availability_score が 1.0 と 0.0 の場合の比較
+- availability_factor によりスコアが最大 ±10% 程度しか変動しないこと。
+
+4. 顔・スタイルの相性（sanity check）
+
+- GuestIntent の visual_style_tags, conversation_preference, massage_pressure_preference, mood_preference_tags を変えたときに、意図通り affinity_score が上がったり下がったりすること。
+
+実装時、必要に応じて追加のテストケースを増やしてよい。
+
+---
+
+## 2. この spec を実装する GitHub Issue テンプレ（例）
+
+```markdown
+タイトル: Implement recommendedScore matching logic
+
+## 背景
+
+`sort=recommended` の並び順を、
+ゲスト・セラピスト・店舗の Win-Win-Win になるように最適化したい。
+
+以下の仕様に基づいて、`recommendedScore(intent, profile)` を実装し、
+単体テストを整備する。
+
+- spec: `specs/matching/recommended_score/spec.md`
+
+## スコープ
+
+- `src/matching/recommendedScore.ts` の新規作成
+  - GuestIntent / TherapistProfile の型定義
+  - affinityScore / popularityScore / fairnessScore / availabilityFactor / recommendedScore などのサブ関数
+- `src/matching/recommendedScore.test.ts` の新規作成
+  - spec に記載のテスト観点をカバーするテスト
+
+## やりたいこと
+
+1. spec.md を読み、必要な型と関数の一覧を洗い出す
+2. `recommendedScore(intent, profile)` を仕様どおり実装
+3. 最低限のテストケースを作成し、`npm test` で通ることを確認
+
+## 受け入れ条件
+
+- `recommendedScore.test.ts` がすべてパスしている
+- 人気が高くても相性が低いセラピストより、
+  相性が高く新人ブーストが効いているセラピストが上位に来るケースが確認できる
+- `availability_score` の影響が ±10% 程度に収まっていること（テストで確認）
+```

--- a/osakamenesu/src/matching/recommendedScore.test.ts
+++ b/osakamenesu/src/matching/recommendedScore.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  availabilityFactor,
+  fairnessScore,
+  popularityScore,
+  recommendedScore,
+  userFitScore,
+  type GuestIntent,
+  type TherapistProfile,
+} from './recommendedScore'
+
+function intent(overrides: Partial<GuestIntent> = {}): GuestIntent {
+  return {
+    area: null,
+    date: null,
+    time_from: null,
+    time_to: null,
+    price_min: null,
+    price_max: null,
+    shop_id: null,
+    visual_style_tags: ['kawaii'],
+    conversation_preference: 'talkative',
+    massage_pressure_preference: 'medium',
+    mood_preference_tags: ['cheerful'],
+    raw_text: '',
+    ...overrides,
+  }
+}
+
+function profile(overrides: Partial<TherapistProfile> = {}): TherapistProfile {
+  return {
+    therapist_id: 't1',
+    visual_style_tags: ['kawaii'],
+    conversation_style: 'talkative',
+    massage_pressure: 'medium',
+    mood_tags: ['cheerful'],
+    total_bookings_30d: 30,
+    repeat_rate_30d: 0.5,
+    avg_review_score: 4.0,
+    price_tier: 2,
+    days_since_first_shift: 100,
+    utilization_7d: 0.5,
+    availability_score: 0.5,
+    ...overrides,
+  }
+}
+
+describe('recommendedScore spec alignment', () => {
+  it('prefers an affinity-strong newcomer over a very popular veteran', () => {
+    const userIntent = intent()
+
+    const veteran = profile({
+      therapist_id: 'vet',
+      total_bookings_30d: 80,
+      repeat_rate_30d: 0.8,
+      avg_review_score: 4.8,
+      days_since_first_shift: 400,
+      utilization_7d: 0.9,
+      availability_score: 0.5,
+    })
+
+    const newcomer = profile({
+      therapist_id: 'newbie',
+      visual_style_tags: ['kawaii', 'natural'],
+      mood_tags: ['cheerful', 'healing'],
+      total_bookings_30d: 5,
+      repeat_rate_30d: 0.2,
+      avg_review_score: 4.0,
+      days_since_first_shift: 5,
+      utilization_7d: 0.1,
+      availability_score: 0.5,
+    })
+
+    const scoreVeteran = recommendedScore(userIntent, veteran)
+    const scoreNewcomer = recommendedScore(userIntent, newcomer)
+
+    expect(scoreNewcomer).toBeGreaterThanOrEqual(scoreVeteran)
+  })
+
+  it('does not let popularity alone outrank a high-affinity profile', () => {
+    const userIntent = intent({ visual_style_tags: ['cool_beauty'] })
+
+    const popularLowAffinity = profile({
+      therapist_id: 'pop',
+      visual_style_tags: ['kawaii'],
+      conversation_style: 'talkative',
+      massage_pressure: 'strong',
+      mood_tags: ['playful'],
+      total_bookings_30d: 90,
+      repeat_rate_30d: 0.9,
+      avg_review_score: 4.9,
+      price_tier: 3,
+      days_since_first_shift: 300,
+      utilization_7d: 0.8,
+    })
+
+    const highAffinityLowPop = profile({
+      therapist_id: 'fit',
+      visual_style_tags: ['cool_beauty'],
+      conversation_style: 'normal',
+      massage_pressure: 'medium',
+      mood_tags: ['calm'],
+      total_bookings_30d: 10,
+      repeat_rate_30d: 0.3,
+      avg_review_score: 4.2,
+      price_tier: 2,
+      days_since_first_shift: 40,
+      utilization_7d: 0.2,
+    })
+
+    const scorePop = recommendedScore(userIntent, popularLowAffinity)
+    const scoreFit = recommendedScore(userIntent, highAffinityLowPop)
+
+    expect(scoreFit).toBeGreaterThan(scorePop)
+  })
+
+  it('availability factor stays within expected range', () => {
+    const userIntent = intent()
+
+    const baseProfile = profile({
+      availability_score: 0.5,
+    })
+
+    const highAvail = { ...baseProfile, availability_score: 1.0 }
+    const lowAvail = { ...baseProfile, availability_score: 0.0 }
+
+    const scoreHigh = recommendedScore(userIntent, highAvail)
+    const scoreLow = recommendedScore(userIntent, lowAvail)
+
+    expect(scoreHigh).toBeGreaterThan(scoreLow)
+
+    const ratio = scoreHigh / scoreLow
+    expect(ratio).toBeLessThanOrEqual(1.2) // 約±10%〜15% の範囲に収まること
+  })
+
+  it('sanity: sub-scores respect weights and ranges', () => {
+    const userIntent = intent()
+    const prof = profile()
+
+    const fit = userFitScore(userIntent, prof)
+    const fairness = fairnessScore(prof)
+    const popularity = popularityScore(prof)
+    const avail = availabilityFactor(prof.availability_score)
+
+    expect(fit).toBeGreaterThan(0)
+    expect(fairness).toBeGreaterThan(0)
+    expect(popularity).toBeGreaterThan(0)
+    expect(avail).toBeGreaterThan(0.89)
+    expect(avail).toBeLessThanOrEqual(1.05)
+  })
+})

--- a/osakamenesu/src/matching/recommendedScore.ts
+++ b/osakamenesu/src/matching/recommendedScore.ts
@@ -1,0 +1,231 @@
+export type ConversationStyle = 'talkative' | 'normal' | 'quiet'
+export type MassagePressure = 'soft' | 'medium' | 'strong'
+export type MoodTag =
+  | 'cheerful'
+  | 'calm'
+  | 'healing'
+  | 'oneesan_mood'
+  | 'playful'
+export type VisualStyleTag =
+  | 'baby_face'
+  | 'kawaii'
+  | 'natural'
+  | 'oneesan'
+  | 'cool_beauty'
+  | 'gal'
+  | 'elegant'
+
+export type GuestIntent = {
+  area: string | null
+  date: string | null
+  time_from: string | null
+  time_to: string | null
+  price_min: number | null
+  price_max: number | null
+  shop_id: string | null
+  visual_style_tags: VisualStyleTag[]
+  conversation_preference: ConversationStyle | null
+  massage_pressure_preference: MassagePressure | null
+  mood_preference_tags: MoodTag[]
+  raw_text: string
+}
+
+export type TherapistProfile = {
+  therapist_id: string
+  visual_style_tags: VisualStyleTag[]
+  conversation_style: ConversationStyle
+  massage_pressure: MassagePressure
+  mood_tags: MoodTag[]
+  total_bookings_30d: number
+  repeat_rate_30d: number
+  avg_review_score: number
+  price_tier: number
+  days_since_first_shift: number
+  utilization_7d: number
+  availability_score: number
+}
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value))
+
+function normalizeBookings(total: number): number {
+  // TODO: adjust saturation threshold based on real booking distribution
+  const saturated = total / 50 // assume 50件で上限近く
+  return clamp01(saturated)
+}
+
+function normalizeReview(avg: number): number {
+  // assume 1〜5 を 0〜1 に線形マッピング
+  return clamp01((avg - 1) / 4)
+}
+
+function normalizePriceTier(tier: number): number {
+  // assume 1〜3 程度の段階を 0〜1 にマッピング
+  return clamp01((tier - 1) / 2)
+}
+
+export function computeFaceTagMatchScore(
+  userTags: VisualStyleTag[],
+  therapistTags: VisualStyleTag[],
+): number {
+  if (userTags.length === 0 || therapistTags.length === 0) {
+    return 0.5
+  }
+
+  const setUser = new Set(userTags)
+  const setTherapist = new Set(therapistTags)
+
+  let intersectionCount = 0
+  for (const tag of setUser) {
+    if (setTherapist.has(tag)) intersectionCount++
+  }
+
+  const maxPossible = Math.min(setUser.size, setTherapist.size)
+  if (maxPossible === 0) return 0
+
+  return intersectionCount / maxPossible
+}
+
+function conversationMatchScore(pref: ConversationStyle | null, actual: ConversationStyle): number {
+  if (!pref) return 0.5
+  if (pref === actual) return 1
+
+  if (
+    (pref === 'talkative' && actual === 'normal') ||
+    (pref === 'normal' && actual === 'talkative') ||
+    (pref === 'quiet' && actual === 'normal') ||
+    (pref === 'normal' && actual === 'quiet')
+  ) {
+    return 0.7
+  }
+
+  return 0.3
+}
+
+function pressureMatchScore(pref: MassagePressure | null, actual: MassagePressure): number {
+  if (!pref) return 0.5
+  if (pref === actual) return 1
+
+  if (
+    (pref === 'soft' && actual === 'medium') ||
+    (pref === 'medium' && actual === 'soft') ||
+    (pref === 'medium' && actual === 'strong') ||
+    (pref === 'strong' && actual === 'medium')
+  ) {
+    return 0.7
+  }
+
+  return 0.3
+}
+
+function moodMatchScore(prefTags: MoodTag[], actualTags: MoodTag[]): number {
+  if (prefTags.length === 0 || actualTags.length === 0) {
+    return 0.5
+  }
+
+  const prefSet = new Set(prefTags)
+  const actSet = new Set(actualTags)
+
+  let intersection = 0
+  for (const t of prefSet) {
+    if (actSet.has(t)) intersection++
+  }
+
+  const maxPossible = Math.min(prefSet.size, actSet.size)
+  if (maxPossible === 0) return 0.3
+
+  const raw = intersection / maxPossible
+  return 0.3 + 0.7 * raw
+}
+
+export function styleMatchScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const conv = conversationMatchScore(intent.conversation_preference, profile.conversation_style)
+  const press = pressureMatchScore(intent.massage_pressure_preference, profile.massage_pressure)
+  const mood = moodMatchScore(intent.mood_preference_tags, profile.mood_tags)
+
+  const wConv = 0.4
+  const wPress = 0.3
+  const wMood = 0.3
+
+  return wConv * conv + wPress * press + wMood * mood
+}
+
+export function affinityScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const look = computeFaceTagMatchScore(intent.visual_style_tags, profile.visual_style_tags)
+  const style = styleMatchScore(intent, profile)
+
+  const wLook = 0.5
+  const wStyle = 0.5
+
+  return wLook * look + wStyle * style
+}
+
+export function popularityScore(profile: TherapistProfile): number {
+  const b = normalizeBookings(profile.total_bookings_30d)
+  const r = clamp01(profile.repeat_rate_30d)
+  const rev = normalizeReview(profile.avg_review_score)
+  const tier = normalizePriceTier(profile.price_tier)
+
+  const raw = 0.4 * b + 0.3 * r + 0.2 * rev + 0.1 * tier
+  return Math.sqrt(clamp01(raw))
+}
+
+export function newcomerScore(daysSinceFirstShift: number): number {
+  if (daysSinceFirstShift <= 7) return 0.9
+  if (daysSinceFirstShift <= 30) return 0.6
+  if (daysSinceFirstShift <= 90) return 0.3
+  return 0.1
+}
+
+export function loadBalanceScore(utilization_7d: number): number {
+  const u = clamp01(utilization_7d)
+  return 1 - u
+}
+
+export function fairnessScore(profile: TherapistProfile): number {
+  const newcomer = newcomerScore(profile.days_since_first_shift)
+  const load = loadBalanceScore(profile.utilization_7d)
+
+  const wNewcomer = 0.5
+  const wLoad = 0.5
+
+  return wNewcomer * newcomer + wLoad * load
+}
+
+export function availabilityFactor(availability_score: number): number {
+  const a = clamp01(availability_score)
+  const minFactor = 0.9
+  const maxFactor = 1.05
+
+  return minFactor + (maxFactor - minFactor) * a
+}
+
+export function userFitScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const affinity = affinityScore(intent, profile)
+  const popularity = popularityScore(profile)
+
+  const wAffinity = 0.7
+  const wPopularity = 0.3
+
+  return wAffinity * affinity + wPopularity * popularity
+}
+
+export function recommendedScore(intent: GuestIntent, profile: TherapistProfile): number {
+  const user_fit = userFitScore(intent, profile)
+  const fair = fairnessScore(profile)
+  const availFac = availabilityFactor(profile.availability_score)
+
+  const wUser = 0.8
+  const wFair = 0.2
+
+  const base = wUser * user_fit + wFair * fair
+  const clampedBase = clamp01(base)
+
+  return clampedBase * availFac
+}
+
+export const __testUtils = {
+  clamp01,
+  normalizeBookings,
+  normalizeReview,
+  normalizePriceTier,
+}


### PR DESCRIPTION
## Summary
- implement recommendedScore and component scores per specs/matching/recommended_score
- add GuestIntent/TherapistProfile types and utility normalizers
- add vitest coverage for newcomer vs veteran, affinity vs popularity, availability factor bounds

## Testing
- pnpm vitest run src/matching/recommendedScore.test.ts
