### PR TITLE
feat(matching): apply recommended scoring to search

### DIFF
--- a/osakamenesu/apps/web/src/app/guest/therapists/[therapistId]/availability/page.tsx
+++ b/osakamenesu/apps/web/src/app/guest/therapists/[therapistId]/availability/page.tsx
@@ -71,7 +71,8 @@ export default function TherapistAvailabilityPage({
         )
         const data = (await resp.json()) as SummaryResponse
         if (!resp.ok) {
-          throw new Error(data?.detail || 'failed to load availability')
+          const message = (data as any)?.detail || 'failed to load availability'
+          throw new Error(message)
         }
         setSummary(data)
         setSelectedDate((prev) => prev || days[0])
@@ -95,7 +96,8 @@ export default function TherapistAvailabilityPage({
         )
         const data = (await resp.json()) as SlotsResponse
         if (!resp.ok) {
-          throw new Error(data?.detail || 'failed to load slots')
+          const message = (data as any)?.detail || 'failed to load slots'
+          throw new Error(message)
         }
         setSlots(data)
       } catch (err) {

--- a/osakamenesu/apps/web/src/features/matching/recommendedRanking.ts
+++ b/osakamenesu/apps/web/src/features/matching/recommendedRanking.ts
@@ -1,0 +1,98 @@
+import {
+  buildGuestIntentFromSearchParams,
+  rankMatchingCandidates,
+  type RecommendedCandidateInput,
+} from '../../../../../src/matching/recommendedSearch'
+
+export type MatchingSearchParams = {
+  area?: string
+  date?: string
+  time_from?: string
+  time_to?: string
+}
+
+export type MatchingCandidateLike = {
+  therapist_id?: string
+  id?: string
+  therapist_name?: string
+  name?: string
+  shop_id?: string
+  shop_name?: string
+  summary?: string | null
+  slots?: { start_at: string; end_at: string }[]
+  look_type?: string | null
+  style_tag?: string | null
+  mood_tag?: string | null
+  talk_level?: string | null
+  price_rank?: number | null
+  availability?: { is_available: boolean | null; rejected_reasons?: string[] }
+  availability_score?: number | null
+  total_bookings_30d?: number | null
+  repeat_rate_30d?: number | null
+  avg_review_score?: number | null
+  days_since_first_shift?: number | null
+  utilization_7d?: number | null
+}
+
+export function mapCandidateToRecommendedInput(
+  raw: MatchingCandidateLike,
+): RecommendedCandidateInput {
+  const availabilityScore = (() => {
+    if (raw.availability && typeof raw.availability.is_available === 'boolean') {
+      return raw.availability.is_available ? 1 : 0
+    }
+    return raw.availability_score ?? null
+  })()
+
+  return {
+    therapist_id: raw.therapist_id || raw.id || '',
+    therapist_name: raw.therapist_name || raw.name,
+    shop_id: raw.shop_id,
+    shop_name: raw.shop_name,
+    look_type: raw.look_type ?? null,
+    style_tag: raw.style_tag ?? null,
+    mood_tag: raw.mood_tag ?? null,
+    talk_level: raw.talk_level ?? null,
+    price_rank: raw.price_rank ?? null,
+    availability_score: availabilityScore,
+    total_bookings_30d: raw.total_bookings_30d ?? null,
+    repeat_rate_30d: raw.repeat_rate_30d ?? null,
+    avg_review_score: raw.avg_review_score ?? null,
+    days_since_first_shift: raw.days_since_first_shift ?? null,
+    utilization_7d: raw.utilization_7d ?? null,
+  }
+}
+
+export function rerankMatchingCandidates(
+  params: MatchingSearchParams,
+  items: MatchingCandidateLike[],
+) {
+  const guestIntent = buildGuestIntentFromSearchParams({
+    area: params.area ?? null,
+    date: params.date ?? null,
+    time_from: params.time_from ?? null,
+    time_to: params.time_to ?? null,
+  })
+
+  const ranked = rankMatchingCandidates(
+    guestIntent,
+    items.map((item) => mapCandidateToRecommendedInput(item)),
+  )
+
+  return ranked.map((rankedItem) => {
+    const original = items.find(
+      (item) => (item.therapist_id || item.id) === rankedItem.therapist_id,
+    )
+
+    return {
+      ...rankedItem,
+      therapist_name:
+        rankedItem.therapist_name || original?.therapist_name || original?.name || '',
+      shop_id: rankedItem.shop_id || original?.shop_id,
+      shop_name: rankedItem.shop_name || original?.shop_name,
+      availability: original?.availability,
+      summary: original?.summary,
+      slots: original?.slots,
+    }
+  })
+}

--- a/osakamenesu/src/matching/recommendedSearch.test.ts
+++ b/osakamenesu/src/matching/recommendedSearch.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildGuestIntentFromSearchParams,
+  rankMatchingCandidates,
+  type RecommendedCandidateInput,
+} from './recommendedSearch'
+
+const intent = buildGuestIntentFromSearchParams({
+  visual_style_tags: ['cool_beauty'],
+  conversation_preference: 'quiet',
+  massage_pressure_preference: 'soft',
+  mood_preference_tags: ['calm'],
+})
+
+describe('rankMatchingCandidates', () => {
+  it('prefers high-affinity newcomer over popular veteran', () => {
+    const candidates: RecommendedCandidateInput[] = [
+      {
+        therapist_id: 'popular-vet',
+        therapist_name: '人気ベテラン',
+        look_type: 'kawaii',
+        talk_level: 'talkative',
+        style_tag: 'strong',
+        mood_tag: 'cheerful',
+        total_bookings_30d: 120,
+        repeat_rate_30d: 0.85,
+        avg_review_score: 4.8,
+        price_rank: 3,
+        days_since_first_shift: 500,
+        utilization_7d: 0.9,
+        availability_score: 0.6,
+      },
+      {
+        therapist_id: 'affinity-newbie',
+        therapist_name: '相性ドンピシャ新人',
+        look_type: 'cool',
+        talk_level: 'quiet',
+        style_tag: 'relax',
+        mood_tag: 'calm',
+        total_bookings_30d: 8,
+        repeat_rate_30d: 0.2,
+        avg_review_score: 4.2,
+        price_rank: 2,
+        days_since_first_shift: 5,
+        utilization_7d: 0.2,
+        availability_score: 0.6,
+      },
+    ]
+
+    const ranked = rankMatchingCandidates(intent, candidates)
+    expect(ranked[0].therapist_id).toBe('affinity-newbie')
+    expect(ranked[1].therapist_id).toBe('popular-vet')
+  })
+
+  it('reflects availability_factor without overwhelming other scores', () => {
+    const base: RecommendedCandidateInput = {
+      therapist_id: 'base',
+      look_type: 'cool',
+      talk_level: 'quiet',
+      style_tag: 'relax',
+      mood_tag: 'calm',
+      total_bookings_30d: 10,
+      repeat_rate_30d: 0.4,
+      avg_review_score: 4.3,
+      price_rank: 2,
+      days_since_first_shift: 40,
+      utilization_7d: 0.4,
+    }
+
+    const lowAvail = { ...base, therapist_id: 'low-avail', availability_score: 0 }
+    const highAvail = { ...base, therapist_id: 'high-avail', availability_score: 1 }
+
+    const ranked = rankMatchingCandidates(intent, [lowAvail, highAvail])
+    expect(ranked[0].therapist_id).toBe('high-avail')
+    const ratio = ranked[0].recommended_score / ranked[1].recommended_score
+    expect(ratio).toBeLessThan(1.2)
+  })
+
+  it('falls back to id ordering when scores tie', () => {
+    const a: RecommendedCandidateInput = {
+      therapist_id: 'a-therapist',
+      look_type: 'natural',
+      mood_tag: 'calm',
+    }
+    const b: RecommendedCandidateInput = {
+      therapist_id: 'b-therapist',
+      look_type: 'natural',
+      mood_tag: 'calm',
+    }
+
+    const ranked = rankMatchingCandidates(intent, [b, a])
+    expect(ranked.map((r) => r.therapist_id)).toEqual(['a-therapist', 'b-therapist'])
+  })
+})

--- a/osakamenesu/src/matching/recommendedSearch.ts
+++ b/osakamenesu/src/matching/recommendedSearch.ts
@@ -1,0 +1,155 @@
+import {
+  type ConversationStyle,
+  type GuestIntent,
+  type MassagePressure,
+  type MoodTag,
+  type TherapistProfile,
+  type VisualStyleTag,
+  recommendedScore,
+} from './recommendedScore'
+
+export type SearchParams = {
+  area?: string | null
+  date?: string | null
+  time_from?: string | null
+  time_to?: string | null
+  price_min?: number | null
+  price_max?: number | null
+  shop_id?: string | null
+  visual_style_tags?: VisualStyleTag[]
+  conversation_preference?: ConversationStyle | null
+  massage_pressure_preference?: MassagePressure | null
+  mood_preference_tags?: MoodTag[]
+  raw_text?: string | null
+}
+
+export type RecommendedCandidateInput = {
+  therapist_id: string
+  therapist_name?: string
+  shop_id?: string
+  shop_name?: string
+  look_type?: string | null
+  style_tag?: string | null
+  mood_tag?: string | null
+  talk_level?: string | null
+  price_rank?: number | null
+  availability_score?: number | null
+  total_bookings_30d?: number | null
+  repeat_rate_30d?: number | null
+  avg_review_score?: number | null
+  days_since_first_shift?: number | null
+  utilization_7d?: number | null
+}
+
+export type RankedCandidate = RecommendedCandidateInput & {
+  recommended_score: number
+}
+
+const LOOK_TYPE_MAP: Record<string, VisualStyleTag> = {
+  cute: 'kawaii',
+  kawaii: 'kawaii',
+  baby_face: 'baby_face',
+  natural: 'natural',
+  oneesan: 'oneesan',
+  beauty: 'elegant',
+  elegant: 'elegant',
+  cool: 'cool_beauty',
+  cool_beauty: 'cool_beauty',
+  gal: 'gal',
+}
+
+const MOOD_TAG_MAP: Record<string, MoodTag> = {
+  cheerful: 'cheerful',
+  calm: 'calm',
+  healing: 'healing',
+  friendly: 'playful',
+  playful: 'playful',
+  energetic: 'cheerful',
+  mature: 'oneesan_mood',
+  oneesan_mood: 'oneesan_mood',
+}
+
+function normalizeConversation(input?: string | null): ConversationStyle {
+  const lowered = input?.toLowerCase()
+  if (lowered === 'talkative') return 'talkative'
+  if (lowered === 'quiet') return 'quiet'
+  return 'normal'
+}
+
+function normalizePressure(input?: string | null): MassagePressure {
+  const lowered = input?.toLowerCase()
+  if (lowered === 'strong') return 'strong'
+  if (lowered === 'relax' || lowered === 'soft') return 'soft'
+  return 'medium'
+}
+
+function normalizeMood(tag?: string | null): MoodTag[] {
+  if (!tag) return []
+  const mapped = MOOD_TAG_MAP[tag.toLowerCase()]
+  return mapped ? [mapped] : []
+}
+
+function normalizeVisual(tag?: string | null): VisualStyleTag[] {
+  if (!tag) return []
+  const mapped = LOOK_TYPE_MAP[tag.toLowerCase()]
+  return mapped ? [mapped] : []
+}
+
+function toPriceTier(price_rank?: number | null): number {
+  if (price_rank === null || price_rank === undefined) return 2
+  if (price_rank <= 1) return 1
+  if (price_rank >= 3) return 3
+  return price_rank
+}
+
+function toTherapistProfile(candidate: RecommendedCandidateInput): TherapistProfile {
+  return {
+    therapist_id: candidate.therapist_id,
+    visual_style_tags: normalizeVisual(candidate.look_type),
+    conversation_style: normalizeConversation(candidate.talk_level),
+    massage_pressure: normalizePressure(candidate.style_tag),
+    mood_tags: normalizeMood(candidate.mood_tag),
+    total_bookings_30d: candidate.total_bookings_30d ?? 0,
+    repeat_rate_30d: candidate.repeat_rate_30d ?? 0,
+    avg_review_score: candidate.avg_review_score ?? 0,
+    price_tier: toPriceTier(candidate.price_rank),
+    days_since_first_shift: candidate.days_since_first_shift ?? 180,
+    utilization_7d: candidate.utilization_7d ?? 0.5,
+    availability_score: candidate.availability_score ?? 0.5,
+  }
+}
+
+export function buildGuestIntentFromSearchParams(params: SearchParams): GuestIntent {
+  return {
+    area: params.area ?? null,
+    date: params.date ?? null,
+    time_from: params.time_from ?? null,
+    time_to: params.time_to ?? null,
+    price_min: params.price_min ?? null,
+    price_max: params.price_max ?? null,
+    shop_id: params.shop_id ?? null,
+    visual_style_tags: params.visual_style_tags ?? [],
+    conversation_preference: params.conversation_preference ?? null,
+    massage_pressure_preference: params.massage_pressure_preference ?? null,
+    mood_preference_tags: params.mood_preference_tags ?? [],
+    raw_text: params.raw_text ?? '',
+  }
+}
+
+export function rankMatchingCandidates(
+  guestIntent: GuestIntent,
+  candidates: RecommendedCandidateInput[],
+): RankedCandidate[] {
+  return candidates
+    .map((c) => {
+      const profile = toTherapistProfile(c)
+      const score = recommendedScore(guestIntent, profile)
+      return { ...c, recommended_score: score }
+    })
+    .sort((a, b) => {
+      if (b.recommended_score !== a.recommended_score) {
+        return b.recommended_score - a.recommended_score
+      }
+      return a.therapist_id.localeCompare(b.therapist_id)
+    })
+}


### PR DESCRIPTION
## Summary
- add recommendedScore-based ranking helper that maps search params and candidate fields
- re-rank guest search and match-chat results when sort=recommended using the new scorer
- add vitest coverage for recommended search ranking and availability influence

## Testing
- pnpm vitest run src/matching/recommendedSearch.test.ts
