### PR TITLE
fix/ci web doppler fallback

### DIFF
--- a/osakamenesu/.github/workflows/ci-e2e.yml
+++ b/osakamenesu/.github/workflows/ci-e2e.yml
@@ -1,0 +1,49 @@
+name: E2E (Playwright)
+
+on:
+  push:
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/ci-e2e.yml'
+  pull_request:
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/ci-e2e.yml'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    environment: Preview
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail fast if E2E_SEED_TOKEN is missing
+        env:
+          E2E_SEED_TOKEN: ${{ secrets.E2E_SEED_TOKEN }}
+        run: |
+          if [ -z "$E2E_SEED_TOKEN" ]; then
+            echo "E2E_SEED_TOKEN is not set. Set the GitHub secret to keep E2E always-on."
+            exit 1
+          fi
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install root deps
+        run: pnpm install --frozen-lockfile
+      - name: Install web deps
+        working-directory: apps/web
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps
+      - name: Run Playwright (shift sync + no-results)
+        working-directory: apps/web
+        env:
+          E2E_BASE_URL: https://osakamenesu.com
+          E2E_API_BASE: https://api.osakamenesu.com
+          E2E_SEED_TOKEN: ${{ secrets.E2E_SEED_TOKEN }}
+        run: pnpm exec playwright test e2e/shift-to-availability-sync.spec.ts e2e/search-no-results.spec.ts e2e/search-card-availability-consistency.spec.ts e2e/shift-to-public-ui-consistency.spec.ts --reporter=line --timeout=120000

--- a/osakamenesu/apps/web/e2e/search-card-availability-consistency.spec.ts
+++ b/osakamenesu/apps/web/e2e/search-card-availability-consistency.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+
+const BASE_URL = process.env.E2E_BASE_URL || 'https://osakamenesu.com'
+const API_BASE =
+  process.env.E2E_API_BASE ||
+  process.env.NEXT_PUBLIC_OSAKAMENESU_API_BASE ||
+  'https://api.osakamenesu.com'
+
+function jstDate(): string {
+  return new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Tokyo' })
+}
+
+async function fetchSlots(therapistId: string): Promise<Array<{ start_at: string; end_at: string }>> {
+  const date = jstDate()
+  const res = await fetch(`${API_BASE}/api/guest/therapists/${therapistId}/availability_slots?date=${date}`, {
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    throw new Error(`availability fetch failed: ${res.status}`)
+  }
+  const json = await res.json().catch(() => ({}))
+  return Array.isArray(json?.slots) ? json.slots : []
+}
+
+test.describe('検索カードと予約スロットの整合性', () => {
+  // 店舗IDが異なる同名カードを区別するため data-shop を利用
+  const requestOnlyShopId = '52c92fb6-bab6-460e-9312-61a16ab98941'
+  const requestOnlyTherapistId = '5a9e68aa-8b58-4f4b-aeda-3be83544adfd'
+  const slotShopSlug = 'e2e-momona-salon'
+  const slotTherapistId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+  test('スロットが無いカードは時刻を出さず、リクエスト表示に統一される', async ({ page }) => {
+    // APIで事前確認
+    const requestSlots = await fetchSlots(requestOnlyTherapistId)
+    expect(requestSlots.length, 'request-only therapist should have 0 slots').toBe(0)
+    const slotSlots = await fetchSlots(slotTherapistId)
+    expect(slotSlots.length, 'slot therapist should have >=1 slot').toBeGreaterThan(0)
+
+    await page.goto(`${BASE_URL}/search?q=SSS&tab=therapists&page=1`, {
+      waitUntil: 'networkidle',
+    })
+
+    const requestCard = page.locator(
+      `[data-testid="therapist-card"][data-shop="${requestOnlyShopId}"]`,
+    )
+    await expect(requestCard).toBeVisible()
+    await expect(requestCard.getByTestId('therapist-availability-badge')).toHaveText(/要問い合わせ/)
+    await expect(requestCard.getByTestId('therapist-cta')).toHaveText(/予約リクエスト/)
+
+    const slotCard = page.locator(
+      `[data-testid="therapist-card"][data-shop="${slotShopSlug}"]`,
+    )
+    await expect(slotCard).toBeVisible()
+    await expect(slotCard.getByTestId('therapist-availability-badge')).toHaveText(/本日|最短|明日/)
+    await expect(slotCard.getByTestId('therapist-cta')).toHaveText(/予約する/)
+  })
+})

--- a/osakamenesu/apps/web/e2e/shift-to-public-ui-consistency.spec.ts
+++ b/osakamenesu/apps/web/e2e/shift-to-public-ui-consistency.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test'
+
+const BASE_URL = process.env.E2E_BASE_URL || 'https://osakamenesu.com'
+const API_BASE =
+  process.env.E2E_API_BASE ||
+  process.env.NEXT_PUBLIC_OSAKAMENESU_API_BASE ||
+  'https://api.osakamenesu.com'
+const E2E_SEED_TOKEN = process.env.E2E_SEED_TOKEN || ''
+
+const SHOP_ID = '11111111-2222-3333-4444-555555555555'
+const THERAPIST_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+const SHOP_SLUG = 'e2e-momona-salon'
+
+type SlotsResponse = { slots: Array<{ start_at: string; end_at: string }>; count: number }
+
+function jstDate(offsetDays = 0): string {
+  const now = new Date()
+  const jst = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }))
+  jst.setDate(jst.getDate() + offsetDays)
+  return jst.toISOString().slice(0, 10)
+}
+
+async function api<T = any>(path: string, opts: RequestInit = {}): Promise<T> {
+  if (!E2E_SEED_TOKEN) {
+    throw new Error('E2E_SEED_TOKEN is required')
+  }
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...opts,
+    headers: {
+      'x-e2e-seed-token': E2E_SEED_TOKEN,
+      'content-type': 'application/json',
+      ...(opts.headers || {}),
+    },
+  })
+  const text = await res.text()
+  if (!res.ok) {
+    throw new Error(`${path} failed: ${res.status} ${text}`)
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text as any
+  }
+}
+
+async function seedOnce() {
+  await api('/internal/e2e/seed', { method: 'POST' })
+}
+
+async function upsertShift({
+  date,
+  startAt,
+  endAt,
+  availabilityStatus = 'available',
+  clearAll = true,
+}: {
+  date: string
+  startAt: string
+  endAt: string
+  availabilityStatus?: string
+  clearAll?: boolean
+}) {
+  await api('/internal/e2e/shifts', {
+    method: 'POST',
+    body: JSON.stringify({
+      therapist_id: THERAPIST_ID,
+      shop_id: SHOP_ID,
+      date,
+      start_at: startAt,
+      end_at: endAt,
+      availability_status: availabilityStatus,
+      clear_all: clearAll,
+    }),
+  })
+}
+
+async function rebuildSlots(date: string) {
+  await api(`/internal/e2e/rebuild_slots?shop_id=${SHOP_ID}&date=${date}`, {
+    method: 'POST',
+  })
+}
+
+async function fetchSlots(date: string): Promise<SlotsResponse> {
+  return api(`/internal/e2e/slots?therapist_id=${THERAPIST_ID}&shop_id=${SHOP_ID}&date=${date}`)
+}
+
+async function waitForSlotCount(date: string, predicate: (n: number) => boolean) {
+  const deadline = Date.now() + 60_000
+  while (Date.now() < deadline) {
+    const res = await fetchSlots(date)
+    if (predicate(res.count)) return res
+    await new Promise((r) => setTimeout(r, 2000))
+  }
+  throw new Error(`slot count did not satisfy predicate within timeout for ${date}`)
+}
+
+test.describe.serial('勤怠→公開UI 整合性', () => {
+  const targetDate = jstDate(1) // 明日を固定
+  const slotStart = `${targetDate}T10:00:00+09:00`
+  const slotEnd = `${targetDate}T12:00:00+09:00`
+
+  test.beforeAll(async () => {
+    await seedOnce()
+  })
+
+  test('slots=0 のときは要問い合わせ表示になる', async ({ page }) => {
+    // シフトをblockedで上書きし、slots=0を作る
+    await upsertShift({
+      date: targetDate,
+      startAt: slotStart,
+      endAt: slotEnd,
+      availabilityStatus: 'off',
+      clearAll: true,
+    })
+    await rebuildSlots(targetDate)
+    const res = await waitForSlotCount(targetDate, (n) => n === 0)
+    expect(res.count).toBe(0)
+
+    await page.goto(`${BASE_URL}/search?q=momona&tab=therapists`, { waitUntil: 'networkidle' })
+    const card = page.locator(`[data-testid="therapist-card"][data-shop="${SHOP_SLUG}"]`).first()
+    await expect(card).toBeVisible()
+    const badge = card.getByTestId('therapist-availability-badge')
+    await expect(badge).toHaveText(/問い合わせ|リクエスト/)
+    await expect(badge).not.toHaveText(/本日|\d{1,2}:\d{2}/)
+    await expect(card.getByTestId('therapist-cta')).toHaveText(/予約リクエスト/)
+  })
+
+  test('slots>=1 のときは時刻表示 + 予約するになる', async ({ page }) => {
+    await upsertShift({
+      date: targetDate,
+      startAt: slotStart,
+      endAt: slotEnd,
+      availabilityStatus: 'available',
+      clearAll: true,
+    })
+    await rebuildSlots(targetDate)
+    const res = await waitForSlotCount(targetDate, (n) => n >= 1)
+    expect(res.count).toBeGreaterThan(0)
+
+    await page.goto(`${BASE_URL}/search?q=momona&tab=therapists`, { waitUntil: 'networkidle' })
+    const card = page.locator(`[data-testid="therapist-card"][data-shop="${SHOP_SLUG}"]`).first()
+    await expect(card).toBeVisible()
+    const badge = card.getByTestId('therapist-availability-badge')
+    await expect(badge).toContainText(/本日|最短|\d{1,2}:\d{2}/)
+    await expect(card.getByTestId('therapist-cta')).toHaveText(/予約する/)
+  })
+})

--- a/osakamenesu/docs/runbook/observability.md
+++ b/osakamenesu/docs/runbook/observability.md
@@ -1,0 +1,56 @@
+# 検索/空き状況の観測手順（運用チェックリスト）
+
+## 1) shops検索 (/api/v1/shops)
+- コマンド例:
+  `curl -s "https://api.osakamenesu.com/api/v1/shops?q=momona"`
+- 期待ログ (info):
+  - `shop_search`
+  - `status_code` / `latency_ms` / `q` / `today` / `available_date` / `result_count`
+- 見たいポイント: result_count が 0 なのか、latency が悪化していないか。
+
+## 2) availability_slots (/api/guest/therapists/{id}/availability_slots)
+- コマンド例（JST今日を指定）:
+  `curl -s "https://api.osakamenesu.com/api/guest/therapists/<therapist_id>/availability_slots?date=YYYY-MM-DD"`
+- 期待ログ (info):
+  - `availability_slots`
+  - `status_code` / `latency_ms` / `therapist_id` / `date` / `result_count`
+- 見たいポイント: result_count が 0 かどうか。0ならシフト/availability同期を確認。
+
+## 3) Meiliタスク失敗
+- 期待ログ (error):
+  - メッセージ: `Meili task failed`
+  - `taskUid` / `index` / `error` / `type`
+- 対処: Meiliのヘルス確認・settings/documents再投入。致命的なら再デプロイ。
+
+## 4) seed運用ポリシー（安全弁）
+- `E2E_SEED_ENABLED` は本番ではデフォルトOFF。必要時のみ一時的に true にし、実行後すぐ戻す。
+- seed実行ログ: `e2e_seed` (info) に remote_addr / therapist_id / shop_id / date が出る。
+- seedレスポンスに検証URLがあるので、手動確認はそれを叩く。
+  - 例: `/api/v1/shops?q=momona`, `/api/guest/therapists/<id>/availability_slots?date=<today>`
+- ON/OFF手順（Fly例）:
+  - ON: `fly secrets set E2E_SEED_ENABLED=true`
+  - OFF: `fly secrets unset E2E_SEED_ENABLED`（原則こちらの状態）
+
+## 5) 0件UX/PR表記（UI回帰）
+- 0件検索: `/search?q=zzzzzzzz` で「該当なし」表示と 2 ボタン（条件クリア / 本日予約できるだけ見る）。
+- PR文言: 「直近の空き枠から自動ピックアップ」「おすすめ（準備中）」で“編集部”表記なし。
+- Playwright回帰テスト `search-no-results.spec.ts` で確認可能。不要時はCIでスキップせず実行推奨。
+
+## 6) CI/E2E実行ポリシー
+- GitHub Actions `.github/workflows/ci-e2e.yml` は push / pull_request のたびに必ず実行（スキップ不可）。
+- シークレット `E2E_SEED_TOKEN` は常時セットが前提。未設定だとワークフローは即Failして気付ける。
+- 実行対象: `shift-to-availability-sync.spec.ts`, `search-no-results.spec.ts`（本番URL/APIを参照）。
+- アーティファクト（スクショ/ログ）はデフォルト保存。CIが落ちたらまずこれを確認。
+
+## 7) 勤怠→slots 生成 / API 監視
+- 勤怠保存ログ: shift保存時に shift_id / staff_id / date_range / tz を確認。
+- slots生成ログ: `availability_generate` (info) で generated_count / reason_if_zero / latency_ms / shift_id / staff_id を確認。
+- 検索APIログ: `shop_search summary` (info) で result_count / today_available_count / next_slot_null_count / q を確認。
+- 「shiftがあるのにslots=0」のときは上記ログを確認し、勤怠入力・休憩・予約/buffer・日跨ぎで除外されていないかを追う。
+
+---
+
+- 2025-12-13 実機確認OK（担当: 坂野） `/search?q=zzzzzzzz`, `/search?q=momona`, PR文言、APIログ出力
+- 2025-12-13 apex反映確認OK（担当: assistant） `/search?q=zzzzzzzz`, `/search?q=momona`, `/search?q=SSS`（“編集部”文言なし）
+- 2025-12-13 APIログ確認OK（担当: assistant） `/api/v1/shops?q=momona`, `/api/guest/therapists/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/availability_slots?date=2025-12-13`
+- 2025-12-13 E2E shift→slots→UI 確認OK（担当: assistant） `/internal/e2e/shifts` + `/internal/e2e/rebuild_slots` でスロット生成/0件を切り替え、`shift-to-public-ui-consistency.spec.ts` でカード表示を検証

--- a/osakamenesu/services/api/app/schemas.py
+++ b/osakamenesu/services/api/app/schemas.py
@@ -196,6 +196,7 @@ class FacetValue(BaseModel):
 
 class NextAvailableSlot(BaseModel):
     start_at: datetime
+    end_at: Optional[datetime] = None
     status: Literal["ok", "maybe"]
 
 


### PR DESCRIPTION
- **fix(ci-web): add doppler fallback and stabilize tests**
- **chore(ci-web): run pnpm with explicit apps/web dir**
- **chore(ci-web): fix doppler pnpm command quoting**
- **chore(ci-web): use existing dashboard reservations smoke test**
- **chore(ci-web): install playwright via pnpm to match project version**
- **chore(ci-web): wipe playwright cache before install**
- **chore(ci-web): pin playwright cache path and enable corepack in storybook**
- **chore(ci-web): add pnpm setup to web-storybook**
- **chore(ci-web): trigger workflow**
- **chore: rerun ci-web**
- **chore(ci-web): add workflow_dispatch trigger**
- **fix(ci-web): install pnpm before cache lookup**
- **fix(web-storybook): remove invalid NODE_OPTIONS flag**
- **chore(ci): add preview e2e workflow dispatch**
