### PR TITLE
fix(ci): unify api paths and checkout

### DIFF
--- a/.github/workflows/ci-api-integration.yml
+++ b/.github/workflows/ci-api-integration.yml
@@ -19,6 +19,9 @@ on:
       - 'requirements-test.txt'
       - '.github/workflows/ci-api-integration.yml'
 
+env:
+  API_DIR: services/api
+
 jobs:
   integration-tests:
     name: "api: integration tests"
@@ -74,7 +77,7 @@ jobs:
           find . -maxdepth 3 -type d -name api -o -name services
 
       - name: Install dependencies
-        working-directory: services/api
+        working-directory: ${{ env.API_DIR }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
@@ -92,7 +95,7 @@ jobs:
           done
 
       - name: Run Alembic migrations
-        working-directory: services/api
+        working-directory: ${{ env.API_DIR }}
         env:
           DATABASE_URL: postgresql+asyncpg://app:app@localhost:5432/osaka_menesu
           MEILI_HOST: http://localhost:7700
@@ -101,7 +104,7 @@ jobs:
           alembic upgrade head
 
       - name: Run unit tests
-        working-directory: services/api
+        working-directory: ${{ env.API_DIR }}
         env:
           DATABASE_URL: postgresql+asyncpg://app:app@localhost:5432/osaka_menesu
           MEILI_HOST: http://localhost:7700
@@ -113,7 +116,7 @@ jobs:
           pytest app/tests -m "not integration" -q --tb=short
 
       - name: Run integration tests
-        working-directory: services/api
+        working-directory: ${{ env.API_DIR }}
         env:
           DATABASE_URL: postgresql+asyncpg://app:app@localhost:5432/osaka_menesu
           MEILI_HOST: http://localhost:7700
@@ -145,7 +148,7 @@ jobs:
           python-version: '3.12'
 
       - name: Check for missing dependencies
-        working-directory: services/api
+        working-directory: ${{ env.API_DIR }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
@@ -192,7 +195,7 @@ jobs:
           python-version: '3.12'
 
       - name: Check enum consistency
-        working-directory: services/api
+        working-directory: ${{ env.API_DIR }}
         run: |
           python -c "
           import re


### PR DESCRIPTION
- add API_DIR env and use it for all working-directories (services/api)
- keep sparse checkout in sync; fetch-depth=0 + fetch-tags to avoid git 128
- integration step block repaired after previous merge mishap
- left a minimal workspace diag; remove later if noisy