### PR TITLE
chore(ci): auto-resolve API_DIR for api workflow

### DIFF
--- a/.github/workflows/ci-api-integration.yml
+++ b/.github/workflows/ci-api-integration.yml
@@ -6,21 +6,26 @@ on:
     branches:
       - main
     paths:
+      - 'services/api/**'
       - 'osakamenesu/services/api/**'
+      - 'docker/api.Dockerfile'
       - 'osakamenesu/docker/api.Dockerfile'
+      - 'docker-compose.test.yml'
       - 'osakamenesu/docker-compose.test.yml'
+      - 'requirements-test.txt'
       - 'osakamenesu/requirements-test.txt'
       - '.github/workflows/ci-api-integration.yml'
   pull_request:
     paths:
+      - 'services/api/**'
       - 'osakamenesu/services/api/**'
+      - 'docker/api.Dockerfile'
       - 'osakamenesu/docker/api.Dockerfile'
+      - 'docker-compose.test.yml'
       - 'osakamenesu/docker-compose.test.yml'
+      - 'requirements-test.txt'
       - 'osakamenesu/requirements-test.txt'
       - '.github/workflows/ci-api-integration.yml'
-
-env:
-  API_DIR: osakamenesu/services/api
 
 jobs:
   integration-tests:
@@ -46,7 +51,6 @@ jobs:
         image: getmeili/meilisearch:v1.11
         env:
           MEILI_MASTER_KEY: test_master_key
-          MEILI_ENV: development
         ports:
           - 7700:7700
 
@@ -57,12 +61,6 @@ jobs:
           submodules: false
           fetch-depth: 0
           fetch-tags: true
-          sparse-checkout: |
-            ${API_DIR}
-            osakamenesu/docker
-            osakamenesu/docker-compose.test.yml
-            osakamenesu/requirements-test.txt
-          sparse-checkout-cone-mode: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -70,26 +68,28 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Verify API_DIR
+      - name: Resolve API_DIR
+        id: resolve-int
         run: |
-          if [ -f "$API_DIR/app/enums.py" ]; then
-            echo "API_DIR OK: $API_DIR"
-          else
-            echo "❌ API_DIR invalid: $API_DIR"
-            echo "Searching for app/enums.py under repo..."
-            find . -maxdepth 5 -path '*/app/enums.py' -print
+          set -e
+          candidates=$(find . -maxdepth 5 -type f -path '*/app/enums.py' | sed 's#/app/enums.py##')
+          echo "Found candidates:"
+          echo "$candidates"
+          API_DIR=$(echo "$candidates" | head -n1)
+          if [ -z "$API_DIR" ]; then
+            echo "❌ app/enums.py not found under repo"
             exit 1
           fi
-
-      - name: Workspace diag
-        run: |
-          echo "pwd -> $(pwd)"
-          ls -la
-          find . -maxdepth 3 -type d -name api -o -name services
+          echo "API_DIR=$API_DIR" >> "$GITHUB_ENV"
+          echo "api_dir=$API_DIR" >> "$GITHUB_OUTPUT"
+          echo "Resolved API_DIR=$API_DIR"
+          ls -la "$API_DIR"
 
       - name: Install dependencies
-        working-directory: ${{ env.API_DIR }}
+        env:
+          API_DIR: ${{ steps.resolve-int.outputs.api_dir }}
         run: |
+          cd "${API_DIR}"
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r ../../requirements-test.txt
@@ -106,17 +106,18 @@ jobs:
           done
 
       - name: Run Alembic migrations
-        working-directory: ${{ env.API_DIR }}
         env:
+          API_DIR: ${{ steps.resolve-int.outputs.api_dir }}
           DATABASE_URL: postgresql+asyncpg://app:app@localhost:5432/osaka_menesu
           MEILI_HOST: http://localhost:7700
           MEILI_MASTER_KEY: test_master_key
         run: |
+          cd "${API_DIR}"
           alembic upgrade head
 
       - name: Run unit tests
-        working-directory: ${{ env.API_DIR }}
         env:
+          API_DIR: ${{ steps.resolve-int.outputs.api_dir }}
           DATABASE_URL: postgresql+asyncpg://app:app@localhost:5432/osaka_menesu
           MEILI_HOST: http://localhost:7700
           MEILI_MASTER_KEY: test_master_key
@@ -124,11 +125,12 @@ jobs:
           API_ORIGIN: http://localhost:3000
           RATE_LIMIT_REDIS_URL: ""
         run: |
+          cd "${API_DIR}"
           pytest app/tests -m "not integration" -q --tb=short
 
       - name: Run integration tests
-        working-directory: ${{ env.API_DIR }}
         env:
+          API_DIR: ${{ steps.resolve-int.outputs.api_dir }}
           DATABASE_URL: postgresql+asyncpg://app:app@localhost:5432/osaka_menesu
           MEILI_HOST: http://localhost:7700
           MEILI_MASTER_KEY: test_master_key
@@ -136,6 +138,7 @@ jobs:
           API_ORIGIN: http://localhost:3000
           RATE_LIMIT_REDIS_URL: ""
         run: |
+          cd "${API_DIR}"
           pytest app/tests_integration -m integration -q --tb=short || echo "No integration tests found, skipping"
 
   dependency-check:
@@ -148,39 +151,41 @@ jobs:
           submodules: false
           fetch-depth: 0
           fetch-tags: true
-          sparse-checkout: |
-            ${API_DIR}
-            osakamenesu/requirements-test.txt
-          sparse-checkout-cone-mode: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Verify API_DIR
+      - name: Resolve API_DIR
+        id: resolve-deps
         run: |
-          if [ -f "$API_DIR/app/enums.py" ]; then
-            echo "API_DIR OK: $API_DIR"
-          else
-            echo "❌ API_DIR invalid: $API_DIR"
-            echo "Searching for app/enums.py under repo..."
-            find . -maxdepth 5 -path '*/app/enums.py' -print
+          set -e
+          candidates=$(find . -maxdepth 5 -type f -path '*/app/enums.py' | sed 's#/app/enums.py##')
+          echo "Found candidates:"
+          echo "$candidates"
+          API_DIR=$(echo "$candidates" | head -n1)
+          if [ -z "$API_DIR" ]; then
+            echo "❌ app/enums.py not found under repo"
             exit 1
           fi
+          echo "API_DIR=$API_DIR" >> "$GITHUB_ENV"
+          echo "api_dir=$API_DIR" >> "$GITHUB_OUTPUT"
+          echo "Resolved API_DIR=$API_DIR"
+          ls -la "$API_DIR"
 
       - name: Check for missing dependencies
-        working-directory: ${{ env.API_DIR }}
+        env:
+          API_DIR: ${{ steps.resolve-deps.outputs.api_dir }}
         run: |
+          cd "${API_DIR}"
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-          # Import check - verify all modules can be imported
-          python -c "
+          python - <<'PY'
           import sys
           sys.path.insert(0, '.')
 
-          # Core imports that must work
           try:
               from app.main import app
               print('✅ app.main imports successfully')
@@ -188,14 +193,13 @@ jobs:
               print(f'❌ Import error in app.main: {e}')
               sys.exit(1)
 
-          # Check optional dependencies are handled gracefully
           try:
               from app.domains.site.guest_matching import guest_matching_search
               print('✅ guest_matching imports successfully')
           except ImportError as e:
               print(f'❌ Import error in guest_matching: {e}')
               sys.exit(1)
-          "
+          PY
 
   enum-consistency-check:
     name: "api: enum consistency"
@@ -207,37 +211,41 @@ jobs:
           submodules: false
           fetch-depth: 0
           fetch-tags: true
-          sparse-checkout: |
-            ${API_DIR}
-          sparse-checkout-cone-mode: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Verify API_DIR
+      - name: Resolve API_DIR
+        id: resolve-enum
         run: |
-          if [ -f "$API_DIR/app/enums.py" ]; then
-            echo "API_DIR OK: $API_DIR"
-          else
-            echo "❌ API_DIR invalid: $API_DIR"
-            echo "Searching for app/enums.py under repo..."
-            find . -maxdepth 5 -path '*/app/enums.py' -print
+          set -e
+          candidates=$(find . -maxdepth 5 -type f -path '*/app/enums.py' | sed 's#/app/enums.py##')
+          echo "Found candidates:"
+          echo "$candidates"
+          API_DIR=$(echo "$candidates" | head -n1)
+          if [ -z "$API_DIR" ]; then
+            echo "❌ app/enums.py not found under repo"
             exit 1
           fi
+          echo "API_DIR=$API_DIR" >> "$GITHUB_ENV"
+          echo "api_dir=$API_DIR" >> "$GITHUB_OUTPUT"
+          echo "Resolved API_DIR=$API_DIR"
+          ls -la "$API_DIR"
 
       - name: Check enum consistency
-        working-directory: ${{ env.API_DIR }}
+        env:
+          API_DIR: ${{ steps.resolve-enum.outputs.api_dir }}
         run: |
-          python -c "
+          cd "${API_DIR}"
+          python - <<'PY'
           import re
           import sys
           from pathlib import Path
 
           errors = []
 
-          # Check enums.py exists and is the single source of truth
           enums_path = Path('app/enums.py')
           if not enums_path.exists():
               print('❌ app/enums.py not found - enum definitions should be centralized')
@@ -245,43 +253,35 @@ jobs:
 
           enums_content = enums_path.read_text()
 
-          # Extract VALUES tuples from enums.py
           values_pattern = r'(\w+_VALUES):\s*Tuple\[str,\s*\.\.\.\]\s*=\s*\(([^)]+)\)'
           enum_values = {}
           for match in re.finditer(values_pattern, enums_content):
               name = match.group(1)
               values_str = match.group(2)
-              values = [v.strip().strip('\"').strip(\"'\") for v in values_str.split(',') if v.strip()]
+              values = [v.strip().strip('"').strip("'") for v in values_str.split(',') if v.strip()]
               enum_values[name] = set(values)
               print(f'Found {name}: {values}')
 
-          # Check models.py imports from enums.py
           models_path = Path('app/models.py')
           models_content = models_path.read_text()
-
           if 'from .enums import' not in models_content and 'from app.enums import' not in models_content:
               errors.append('models.py should import enum values from enums.py')
 
-          # Check schemas.py imports from enums.py
           schemas_path = Path('app/schemas.py')
           schemas_content = schemas_path.read_text()
-
           if 'from .enums import' not in schemas_content and 'from app.enums import' not in schemas_content:
               errors.append('schemas.py should import enum Literals from enums.py')
 
-          # Check for hardcoded 'active' status (common mistake)
           api_dir = Path('app')
           for py_file in api_dir.rglob('*.py'):
               if 'test' in str(py_file) or 'alembic' in str(py_file) or 'enums.py' in str(py_file):
                   continue
               content = py_file.read_text()
-
-              # Check for hardcoded 'active' which is not a valid therapist status
-              if re.search(r'therapist.*status.*[\"\\']active[\"\\']', content, re.IGNORECASE):
+              if re.search(r'therapist.*status.*["\']active["\']', content, re.IGNORECASE):
                   for i, line in enumerate(content.split('\n'), 1):
-                      if \"'active'\" in line or '\"active\"' in line:
+                      if "'active'" in line or '"active"' in line:
                           if 'therapist' in line.lower() and 'status' in line.lower():
-                              errors.append(f'{py_file}:{i}: Found hardcoded \"active\" status (use enums.py values)')
+                              errors.append(f'{py_file}:{i}: Found hardcoded "active" status (use enums.py values)')
 
           if errors:
               print('\n❌ Enum consistency errors found:')
@@ -290,4 +290,4 @@ jobs:
               sys.exit(1)
           else:
               print('\n✅ All enum checks passed')
-          "
+          PY


### PR DESCRIPTION
- remove sparse checkout; full checkout with fetch-depth:0 + fetch-tags
- resolve API_DIR by finding app/enums.py (fail fast, print candidates)
- monitor both services/api and osakamenesu/services/api in triggers
- run steps with cd "" (no working-directory)
- actionlint clean