### PR TITLE
feat: P0 business hours + server-computed reservation end_at

### DIFF
--- a/osakamenesu/services/api/alembic/versions/0042_add_guest_reservation_timing_columns.py
+++ b/osakamenesu/services/api/alembic/versions/0042_add_guest_reservation_timing_columns.py
@@ -1,0 +1,44 @@
+"""add timing columns to guest_reservations
+
+Revision ID: 0042_add_guest_reservation_timing_columns
+Revises: 0041_add_default_slot_duration
+Create Date: 2025-12-14
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0042_add_guest_reservation_timing_columns"
+down_revision = "0041_add_default_slot_duration"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guest_reservations",
+        sa.Column(
+            "planned_extension_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "guest_reservations",
+        sa.Column(
+            "buffer_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("guest_reservations", "buffer_minutes")
+    op.drop_column("guest_reservations", "planned_extension_minutes")

--- a/osakamenesu/services/api/app/models.py
+++ b/osakamenesu/services/api/app/models.py
@@ -926,6 +926,12 @@ class GuestReservation(Base):
         DateTime(timezone=True), nullable=False, index=True
     )
     duration_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    planned_extension_minutes: Mapped[int] = mapped_column(
+        Integer, default=0, nullable=False, server_default="0"
+    )
+    buffer_minutes: Mapped[int] = mapped_column(
+        Integer, default=0, nullable=False, server_default="0"
+    )
     course_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True
     )

--- a/osakamenesu/services/api/app/services/business_hours.py
+++ b/osakamenesu/services/api/app/services/business_hours.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from ..utils.datetime import JST, ensure_jst_datetime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BookingRules:
+    base_buffer_minutes: int = 0
+    max_extension_minutes: int = 0
+    extension_step_minutes: int = 15
+
+
+@dataclass(frozen=True)
+class BusinessHoursSegment:
+    open: time
+    close: time
+
+
+@dataclass(frozen=True)
+class BusinessHoursConfig:
+    tz: ZoneInfo
+    weekly: dict[int, list[BusinessHoursSegment]]
+    overrides: dict[date, list[BusinessHoursSegment]]
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except Exception:
+        return default
+
+
+def load_booking_rules_from_profile(profile: Any | None) -> BookingRules:
+    if profile is None:
+        return BookingRules()
+    contact_json = getattr(profile, "contact_json", None)
+    if not isinstance(contact_json, dict):
+        return BookingRules()
+
+    raw = contact_json.get("booking_rules")
+    if raw is None:
+        return BookingRules()
+    if not isinstance(raw, dict):
+        logger.warning("booking_rules_invalid_type: %s", type(raw).__name__)
+        return BookingRules()
+
+    base_buffer = _coerce_int(raw.get("base_buffer_minutes"), default=0)
+    max_ext = _coerce_int(raw.get("max_extension_minutes"), default=0)
+    step = _coerce_int(raw.get("extension_step_minutes"), default=15)
+
+    if base_buffer < 0 or max_ext < 0:
+        logger.warning("booking_rules_invalid_negative: %s", raw)
+        return BookingRules()
+    if step <= 0:
+        logger.warning("booking_rules_invalid_step: %s", raw)
+        return BookingRules()
+
+    return BookingRules(
+        base_buffer_minutes=base_buffer,
+        max_extension_minutes=max_ext,
+        extension_step_minutes=step,
+    )
+
+
+def _parse_hhmm(value: Any) -> time | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        hour_str, minute_str = raw.split(":", 1)
+        hour = int(hour_str)
+        minute = int(minute_str)
+        if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+            return None
+        return time(hour=hour, minute=minute)
+    except Exception:
+        return None
+
+
+def load_business_hours_from_profile(profile: Any | None) -> BusinessHoursConfig | None:
+    if profile is None:
+        return None
+    contact_json = getattr(profile, "contact_json", None)
+    if not isinstance(contact_json, dict):
+        return None
+    raw = contact_json.get("booking_hours")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        logger.warning("booking_hours_invalid_type: %s", type(raw).__name__)
+        return None
+
+    tz_name = raw.get("tz") or "Asia/Tokyo"
+    tz: ZoneInfo
+    try:
+        tz = ZoneInfo(str(tz_name))
+    except Exception:
+        logger.warning("booking_hours_invalid_tz: %s", tz_name)
+        return None
+
+    weekly: dict[int, list[BusinessHoursSegment]] = {}
+    weekly_raw = raw.get("weekly")
+    if isinstance(weekly_raw, list):
+        for entry in weekly_raw:
+            if not isinstance(entry, dict):
+                logger.warning("booking_hours_weekly_invalid_entry: %s", entry)
+                return None
+            weekday = entry.get("weekday")
+            if not isinstance(weekday, int) or weekday < 0 or weekday > 6:
+                logger.warning("booking_hours_weekly_invalid_weekday: %s", weekday)
+                return None
+            segments_raw = entry.get("segments") or []
+            if not isinstance(segments_raw, list):
+                logger.warning(
+                    "booking_hours_weekly_invalid_segments: %s", segments_raw
+                )
+                return None
+            segments: list[BusinessHoursSegment] = []
+            for seg in segments_raw:
+                if not isinstance(seg, dict):
+                    logger.warning("booking_hours_weekly_invalid_segment: %s", seg)
+                    return None
+                if seg.get("is_closed") is True:
+                    continue
+                open_t = _parse_hhmm(seg.get("open"))
+                close_t = _parse_hhmm(seg.get("close"))
+                if open_t is None or close_t is None:
+                    logger.warning("booking_hours_weekly_invalid_times: %s", seg)
+                    return None
+                segments.append(BusinessHoursSegment(open=open_t, close=close_t))
+            weekly[weekday] = segments
+
+    overrides: dict[date, list[BusinessHoursSegment]] = {}
+    overrides_raw = raw.get("overrides")
+    if isinstance(overrides_raw, list):
+        for entry in overrides_raw:
+            if not isinstance(entry, dict):
+                logger.warning("booking_hours_override_invalid_entry: %s", entry)
+                return None
+            date_raw = entry.get("date")
+            if not isinstance(date_raw, str):
+                logger.warning("booking_hours_override_invalid_date: %s", date_raw)
+                return None
+            try:
+                day = date.fromisoformat(date_raw)
+            except ValueError:
+                logger.warning("booking_hours_override_invalid_date: %s", date_raw)
+                return None
+            if entry.get("is_closed") is True:
+                overrides[day] = []
+                continue
+            open_t = _parse_hhmm(entry.get("open"))
+            close_t = _parse_hhmm(entry.get("close"))
+            if open_t is None or close_t is None:
+                logger.warning("booking_hours_override_invalid_times: %s", entry)
+                return None
+            overrides[day] = [BusinessHoursSegment(open=open_t, close=close_t)]
+
+    if not weekly and not overrides:
+        logger.warning("booking_hours_empty_config: %s", raw)
+        return None
+
+    return BusinessHoursConfig(tz=tz, weekly=weekly, overrides=overrides)
+
+
+def _iter_open_intervals(
+    cfg: BusinessHoursConfig,
+    target_date: date,
+) -> list[tuple[datetime, datetime]]:
+    segments = cfg.overrides.get(target_date)
+    if segments is None:
+        segments = cfg.weekly.get(target_date.weekday(), [])
+
+    intervals: list[tuple[datetime, datetime]] = []
+    for seg in segments:
+        start_dt = datetime.combine(target_date, seg.open).replace(tzinfo=cfg.tz)
+        end_dt = datetime.combine(target_date, seg.close).replace(tzinfo=cfg.tz)
+        if end_dt <= start_dt:
+            end_dt = end_dt + timedelta(days=1)
+        intervals.append((start_dt, end_dt))
+    return intervals
+
+
+def is_within_business_hours(
+    cfg: BusinessHoursConfig,
+    start_at: datetime,
+    end_at: datetime,
+) -> bool:
+    if start_at.tzinfo is None or end_at.tzinfo is None:
+        # The caller contract says inputs are timezone-aware.
+        start_at = ensure_jst_datetime(start_at)
+        end_at = ensure_jst_datetime(end_at)
+
+    if end_at <= start_at:
+        return False
+
+    start_local = start_at.astimezone(cfg.tz)
+    end_local = end_at.astimezone(cfg.tz)
+
+    start_date = start_local.date()
+    candidates = {start_date, start_date - timedelta(days=1)}
+    for day in candidates:
+        for open_dt, close_dt in _iter_open_intervals(cfg, day):
+            if start_local >= open_dt and end_local <= close_dt:
+                return True
+    return False
+
+
+__all__ = [
+    "BookingRules",
+    "BusinessHoursConfig",
+    "load_booking_rules_from_profile",
+    "load_business_hours_from_profile",
+    "is_within_business_hours",
+]

--- a/osakamenesu/services/api/app/tests/test_business_hours.py
+++ b/osakamenesu/services/api/app/tests/test_business_hours.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, time
+from zoneinfo import ZoneInfo
+
+from app.services.business_hours import (
+    BusinessHoursConfig,
+    BusinessHoursSegment,
+    is_within_business_hours,
+)
+
+
+def test_business_hours_overnight_ok() -> None:
+    tz = ZoneInfo("Asia/Tokyo")
+    # Monday (0) 18:00-02:00 covers Tuesday 01:00.
+    cfg = BusinessHoursConfig(
+        tz=tz,
+        weekly={0: [BusinessHoursSegment(open=time(18, 0), close=time(2, 0))]},
+        overrides={},
+    )
+
+    start_at = datetime(2025, 1, 7, 1, 0, tzinfo=tz)  # Tue
+    end_at = start_at + timedelta(minutes=60)
+    assert is_within_business_hours(cfg, start_at, end_at) is True
+
+
+def test_business_hours_close_exceed_ng() -> None:
+    tz = ZoneInfo("Asia/Tokyo")
+    cfg = BusinessHoursConfig(
+        tz=tz,
+        weekly={0: [BusinessHoursSegment(open=time(18, 0), close=time(2, 0))]},
+        overrides={},
+    )
+
+    start_at = datetime(2025, 1, 7, 1, 30, tzinfo=tz)  # Tue
+    # duration 30 + extension 15 + buffer 20 => 65 minutes => 02:35 (exceeds 02:00)
+    end_at = start_at + timedelta(minutes=65)
+    assert is_within_business_hours(cfg, start_at, end_at) is False

--- a/osakamenesu/services/api/app/tests/test_guest_reservation_time_calc.py
+++ b/osakamenesu/services/api/app/tests/test_guest_reservation_time_calc.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from app.domains.site.guest_reservations import compute_booking_times
+
+
+def test_compute_booking_times_resolves_course_duration_and_buffer() -> None:
+    tz = ZoneInfo("Asia/Tokyo")
+    shop_id = uuid4()
+    course_id = uuid4()
+    profile = SimpleNamespace(
+        id=shop_id,
+        contact_json={
+            "menus": [
+                {
+                    "id": str(course_id),
+                    "name": "Basic",
+                    "price": 10000,
+                    "duration_minutes": 60,
+                }
+            ],
+            "booking_rules": {
+                "base_buffer_minutes": 20,
+                "max_extension_minutes": 120,
+                "extension_step_minutes": 15,
+            },
+        },
+    )
+
+    start_at = datetime(2025, 1, 7, 10, 0, tzinfo=tz)
+    (
+        service_duration_minutes,
+        planned_extension_minutes,
+        buffer_minutes,
+        service_end_at,
+        occupied_end_at,
+        err,
+    ) = compute_booking_times(
+        profile=profile,
+        start_at=start_at,
+        course_id=course_id,
+        base_duration_minutes=None,
+        planned_extension_minutes=15,
+    )
+
+    assert err is None
+    assert service_duration_minutes == 75
+    assert planned_extension_minutes == 15
+    assert buffer_minutes == 20
+    assert service_end_at == start_at + timedelta(minutes=75)
+    assert occupied_end_at == start_at + timedelta(minutes=95)
+
+
+def test_compute_booking_times_rejects_invalid_extension_step() -> None:
+    tz = ZoneInfo("Asia/Tokyo")
+    profile = SimpleNamespace(
+        id=uuid4(),
+        contact_json={
+            "booking_rules": {
+                "base_buffer_minutes": 0,
+                "max_extension_minutes": 120,
+                "extension_step_minutes": 15,
+            }
+        },
+    )
+    start_at = datetime(2025, 1, 7, 10, 0, tzinfo=tz)
+    *_vals, err = compute_booking_times(
+        profile=profile,
+        start_at=start_at,
+        course_id=None,
+        base_duration_minutes=30,
+        planned_extension_minutes=20,  # not multiple of 15
+    )
+    assert err == "invalid_extension"

--- a/osakamenesu/services/api/app/tests/test_guest_reservations_business_hours_api.py
+++ b/osakamenesu/services/api/app/tests/test_guest_reservations_business_hours_api.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import get_session
+from app.domains.site import guest_reservations as domain
+from app.main import app
+
+
+class DummySession:
+    def add(self, _obj) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+    async def refresh(self, _obj) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+    async def rollback(self) -> None:
+        return None
+
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    app.dependency_overrides[get_session] = lambda: DummySession()
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.pop(get_session, None)
+
+
+def test_create_guest_reservation_rejects_outside_business_hours(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tz = ZoneInfo("Asia/Tokyo")
+    shop_id = uuid4()
+    therapist_id = uuid4()
+
+    profile = SimpleNamespace(
+        id=shop_id,
+        contact_json={
+            "booking_hours": {
+                "tz": "Asia/Tokyo",
+                "weekly": [
+                    {
+                        "weekday": 0,  # Monday 18:00-02:00 covers Tuesday 01:xx
+                        "segments": [{"open": "18:00", "close": "02:00"}],
+                    }
+                ],
+            },
+            "booking_rules": {
+                "base_buffer_minutes": 20,
+                "max_extension_minutes": 120,
+                "extension_step_minutes": 15,
+            },
+        },
+    )
+
+    async def fake_fetch_profile(_db, _shop_id):  # type: ignore[no-untyped-def]
+        return profile
+
+    async def fake_is_available(_db, _tid, _start_at, _end_at, lock=False):  # type: ignore[no-untyped-def]
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "_try_fetch_profile", fake_fetch_profile)
+    monkeypatch.setattr(domain, "is_available", fake_is_available)
+    monkeypatch.setattr(
+        domain,
+        "now_utc",
+        lambda: datetime(2025, 1, 6, 0, 0, tzinfo=timezone.utc),
+    )
+
+    start_at = datetime(2025, 1, 7, 1, 30, tzinfo=tz)
+    payload = {
+        "shop_id": str(shop_id),
+        "therapist_id": str(therapist_id),
+        "start_at": start_at.isoformat(),
+        "end_at": (start_at + domain.timedelta(minutes=30)).isoformat(),
+        "duration_minutes": 30,
+        "planned_extension_minutes": 15,
+    }
+    res = client.post("/api/guest/reservations", json=payload)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "rejected"
+    assert "outside_business_hours" in (body.get("debug") or {}).get(
+        "rejected_reasons", []
+    )

--- a/osakamenesu/specs/reservations/core.yaml
+++ b/osakamenesu/specs/reservations/core.yaml
@@ -19,6 +19,7 @@ contexts:
           start_at: { type: string, format: date-time }
           end_at: { type: string, format: date-time }
       menu_id: { type: string, required: false }
+      planned_extension_minutes: { type: integer, required: false, description: "Optional planned extension minutes (step-based). Server validates using booking_rules." }
       price: { type: number, required: false }
       payment_method: { type: string, required: false, description: "e.g. cash, card (v1 as free text)" }
       contact_info: { type: object, required: false, description: "email/phone/line_id etc." }
@@ -61,6 +62,8 @@ endpoints:
     notes:
       - v1 status may be set to confirmed immediately if no manual approval flow exists; pending is also acceptable but must be reflected consistently in tests.
       - Duplicate detection: same therapist_id AND identical slot (start/end) should return 400/409.
+      - P0: end_at is derived server-side from (duration + planned_extension_minutes + after-buffer minutes). Client-provided end_at may be ignored for consistency.
+      - P0: if profile.contact_json.booking_hours is configured, requests outside business hours should be rejected with reason outside_business_hours.
   - id: reservations.cancel
     method: POST
     path: /api/guest/reservations/{id}/cancel
@@ -89,7 +92,7 @@ flow:
     Overlap is defined as start_at < other.end_at AND other.start_at < end_at (half-open interval).
     Pending/confirmed reservations block the slot; cancelled does not.
     Reservations must be fully inside an available therapist shift; otherwise reject with no_shift/on_break.
-    Buffer minutes between reservations/shifts are out of scope for v1 (TODO).
+    P0: after-buffer minutes may be applied to the occupied end_at based on booking_rules.base_buffer_minutes (TODO: pre-buffer and shift buffer rules).
   scope_notes: |
     Payments, notifications, and approval workflows are out-of-scope for v1 and can be added later.
     If a shift is missing or marked unavailable, treat the slot as closed.


### PR DESCRIPTION
## 目的
予約作成の占有レンジをサーバ側で一貫計算し（course + extension + after buffer）、営業時間外の予約をP0で抑止できるようにする。

## 変更概要（P0）
- 営業時間/ルール読込＋判定（Profile.contact_json の booking_hours / booking_rules）
  - 未設定/不正の場合は **制限なし（互換維持）**
  - 日跨ぎ営業時間（例: 18:00-02:00）をサポート
- 予約作成で end_at をサーバ計算
  - service_end_at（course + extension）
  - occupied_end_at（service_end_at + buffer）
  - is_available は常に **occupiedレンジ**で判定
- DB: guest_reservations に planned_extension_minutes / buffer_minutes を焼き付け（再現可能に）
- Rejection reason: outside_business_hours（fail-soft）

## テスト
- business_hours の日跨ぎOK/閉店超過NG
- 予約の時間計算（course/extension/buffer）
- API: outside_business_hours が返ること
- pytest: 429 passed, 37 skipped

## 互換性
- booking_hours未設定の店舗は従来どおり予約可能（no restriction）
- クライアントの end_at は受けるが、サーバ計算が正（P0ノートをspecに追記）