### PR TITLE
fix(tests): align today_available fixtures with JST

### DIFF
--- a/osakamenesu/services/api/app/tests/test_admin_site_integration.py
+++ b/osakamenesu/services/api/app/tests/test_admin_site_integration.py
@@ -228,7 +228,9 @@ def _build_profile_fixture() -> models.Profile:
 def _build_availability(
     profile_id: uuid.UUID,
 ) -> tuple[AvailabilityCalendar, NextAvailableSlot, AvailabilitySlot]:
-    slot_date = date.today()
+    # Align with production behavior (JST-based "today") to avoid CI flakiness when
+    # the runner timezone is UTC.
+    slot_date = now_jst().date()
     slot_start = datetime.combine(slot_date, time(hour=6, minute=0, tzinfo=JST))
     slot_end = slot_start + timedelta(hours=1)
     staff_id = uuid.uuid4()

--- a/osakamenesu/services/api/app/tests/test_shop_detail_api.py
+++ b/osakamenesu/services/api/app/tests/test_shop_detail_api.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.db import get_session
 from app.domains.site.services import shop_services
+from app.utils.datetime import now_jst
 
 
 SHOP_ID = uuid4()
@@ -373,7 +374,9 @@ def test_get_shop_detail_with_availability(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     profile = _create_mock_profile()
-    today = date.today()
+    # Align with production behavior (JST-based "today") to avoid CI flakiness when
+    # the runner timezone is UTC.
+    today = now_jst().date()
     now = datetime.now()
 
     mock_calendar = AvailabilityCalendar(

--- a/osakamenesu/services/api/app/tests/test_shop_therapists_api.py
+++ b/osakamenesu/services/api/app/tests/test_shop_therapists_api.py
@@ -172,7 +172,9 @@ def test_list_shop_therapists_with_availability(
     """Test therapist listing with availability slots."""
     profile = _create_mock_profile()
     therapist = _create_mock_therapist(THERAPIST_ID_1, "Therapist 1")
-    today = date.today()
+    # Align with production behavior (JST-based "today") to avoid CI flakiness when
+    # the runner timezone is UTC.
+    today = datetime.now(JST).date()
     shift = _create_mock_shift(THERAPIST_ID_1, today)
 
     _setup_mocks(monkeypatch, profile=profile, therapists=[therapist], shifts=[shift])


### PR DESCRIPTION
CIのrunner timezone(UTC)と実装のJST基準の"today"がズレるタイミングで、today_available を True 期待しているテストが落ちるのを修正します。\n\n- テストデータ生成の date.today() を JST基準(now_jst().date() / datetime.now(JST).date()) に置換\n- 実装側は now_jst().date() で判定しているため、テストも同じ基準に揃えてflakeを排除\n\nNo behavior change (tests only).