### PR TITLE
test: lock JST-based today_available (prevent CI flake)

### DIFF
--- a/docs/staging.md
+++ b/docs/staging.md
@@ -9,6 +9,33 @@
 - STGは「2店舗 + 2セラ + 未来シフト」のみで再現/検証する
 - APIはアイドル時 0台（コスト最小化）
 
+## Time zone invariants（JST基準）
+
+- `today_available` と `availability_calendar.days[].is_today` は **JSTの「今日」**（`now_jst().date()`）で判定される
+- UTC日付とJST日付がズレる時間帯でも、JST側の「今日」が正になる
+
+再現（STG / GET 1回）:
+
+```bash
+curl -sS \
+  https://osakamenesu-api-stg.fly.dev/api/v1/shops/ca40f333-cc6f-492a-8d0c-d137448fad67
+```
+
+証跡（UTC=2025-12-14 / JST=2025-12-15 の境界で、JST日付が `is_today=true` になる例）:
+
+```json
+{
+  "shop_id": "ca40f333-cc6f-492a-8d0c-d137448fad67",
+  "today_available": true,
+  "next_available_at": "2025-12-15T03:00:00+09:00",
+  "availability_calendar_first_day": {
+    "date": "2025-12-15",
+    "is_today": true,
+    "first_slot_start_at": "2025-12-15T00:00:00+09:00"
+  }
+}
+```
+
 ## 対象リソース
 
 - Fly app: `osakamenesu-api-stg`

--- a/osakamenesu/services/api/app/tests/test_shop_therapists_api.py
+++ b/osakamenesu/services/api/app/tests/test_shop_therapists_api.py
@@ -375,7 +375,9 @@ def test_recommended_score_with_availability_boost(
     therapist_with_avail.display_order = 1
     therapist_no_avail.display_order = 1
 
-    today = date.today()
+    # Align with production behavior (JST-based "today") to avoid CI flakiness when
+    # the runner timezone is UTC.
+    today = datetime.now(JST).date()
     shift = _create_mock_shift(THERAPIST_ID_1, today)
 
     _setup_mocks(


### PR DESCRIPTION
UTC/JSTの日付境界（例: 17:14Z = 翌日JST）で `today_available` がズレてCIが不安定になり得るため、JST基準の挙動をテストとRunbookに固定します。

- `test_today_available_is_jst_based` を追加（固定UTC時刻→JST変換、JST日付で `today_available`/`is_today` を検証）
- 追加で1テストの `date.today()` を JST基準に揃えて将来のflake芽を減らす
- `docs/staging.md` に Time zone invariants（JST基準）を追記し、STGでの再現GETを記載

Checks: `cd osakamenesu/services/api && pytest -q`
