### PR TITLE
chore: P1 plan for reservation holds (TTL) + room_count + locking

### DIFF
--- a/osakamenesu/docs/p1-hold-room-lock-plan.md
+++ b/osakamenesu/docs/p1-hold-room-lock-plan.md
@@ -1,0 +1,109 @@
+# P1 plan: holds (TTL) / room_count / DB locking
+
+This document is **planning-only**. It captures current behavior and a minimal vertical-slice plan for P1.
+
+## Current state (facts)
+
+### Reservation statuses
+
+- Shop-side reservation status:
+  - Defined in `osakamenesu/services/api/app/enums.py` (`ReservationStatusLiteral`)
+  - Values: `pending`, `confirmed`, `declined`, `cancelled`, `expired`
+- Guest reservation status:
+  - Defined in `osakamenesu/services/api/app/enums.py` (`GuestReservationStatusLiteral`)
+  - Values: `draft`, `pending`, `confirmed`, `cancelled`, `no_show`
+
+### Which statuses block availability (SoT today)
+
+- Blocking statuses are defined in `osakamenesu/services/api/app/domains/site/therapist_availability.py`
+  - `ACTIVE_RESERVATION_STATUSES = ("pending", "confirmed")`
+  - Used in `_fetch_reservations()` and `has_overlapping_reservation()`
+
+### DB locking (today)
+
+- Reservation overlap check supports row locking via `SELECT ... FOR UPDATE`:
+  - `has_overlapping_reservation(..., lock=True)` in `osakamenesu/services/api/app/domains/site/therapist_availability.py`
+  - It applies `stmt.with_for_update()` to a `GuestReservation` query (if supported by DB)
+- Guest reservation create uses the lock path:
+  - `is_available(..., lock=True)` from `osakamenesu/services/api/app/domains/site/guest_reservations.py`
+- No Postgres advisory lock usage was found under `osakamenesu/services/api/app` (grep: `advisory`)
+
+## P1 spec (what we want to lock-in)
+
+### Holds (TTL)
+
+Spec file:
+
+- `specs/reservations/holds.yaml`
+
+Key points:
+
+- Add guest reservation statuses: `reserved` and `expired`
+- Holds are `reserved` with `reserved_until` (TTL minutes from `created_at`)
+- `reserved` blocks availability just like `pending`/`confirmed`
+- Add idempotency expectations (Idempotency-Key) for hold creation
+
+### Room_count (design only in P1 plan)
+
+Spec file:
+
+- `specs/availability/core.yaml` (`p1_room_count`)
+
+Rule:
+
+- For a shop, overlapping blocking reservations must not exceed `room_count`
+- Overlap definition is half-open: `[start_at, end_at)`
+
+## Implementation plan (vertical slices)
+
+### Slice 1: Holds (reserved/expired) + TTL semantics (no room_count yet)
+
+DB changes (planned):
+
+- Add `GuestReservation.reserved_until TIMESTAMPTZ NULL`
+- Add `GuestReservation.idempotency_key TEXT NULL` (unique-ish scope to be decided)
+- Extend `GuestReservationStatusLiteral` to include `reserved`, `expired`
+
+Runtime behavior:
+
+- New path (or flag on existing create) to create `reserved` holds
+- `therapist_availability` treats `reserved` as blocking
+- Expiry should be enforced on read (deterministic) and by async cleanup (best-effort)
+
+### Slice 2: Enforce room_count (application-level)
+
+DB change (planned):
+
+- `profiles.room_count INT NOT NULL DEFAULT 1`
+
+Implementation approach:
+
+- Count overlapping blocking reservations for the shop in the same transaction
+- Reject if count >= room_count
+- Keep the overlap definition consistent with `_overlaps()` / SQL overlap query
+
+### Slice 3: Stronger concurrency guarantees (later)
+
+Options:
+
+- Postgres `pg_advisory_xact_lock` per (shop_id + time bucket) to serialize reservations
+- DB-level exclusion constraints (EXCLUDE USING gist on tstzrange) when ready
+
+## Tests plan (write-up only)
+
+- Holds:
+  - `reserved` blocks availability like `pending`/`confirmed`
+  - TTL expiry causes it to stop blocking (expired does not block)
+- room_count:
+  - room_count=2 allows 2 overlaps but rejects the 3rd
+- Idempotency:
+  - same key + same payload returns the same hold
+  - same key + different payload rejects
+
+## Checklist for P1 delivery
+
+- [ ] Spec updated (holds + availability core)
+- [ ] Migration plan written (reserved_until, idempotency_key, room_count)
+- [ ] Locking strategy chosen for Slice 1 (row-lock vs advisory lock)
+- [ ] Tests cover reserved/expired + blocking rules
+- [ ] Runbook note: time zone invariants remain JST-based

--- a/osakamenesu/specs/availability/core.yaml
+++ b/osakamenesu/specs/availability/core.yaml
@@ -61,3 +61,27 @@ implementation_notes:
     constraints:
       - slots_json の slot は start/end がシフト内に完全に収まるものだけを生成する
       - slots_json の slot には staff_id(=therapist_id) を含め、セラピスト単位の表示を壊さない
+
+p1:
+  holds:
+    description: >
+      予約作成の TTL hold を導入する際の availability 影響（計画）。
+    GuestReservation:
+      blocking_statuses_add: [reserved]
+      non_blocking_statuses_add: [expired]
+  room_count:
+    description: >
+      店舗ごとの “同時刻帯の予約数上限” を room_count で制御する（計画）。
+    db_plan:
+      Profile:
+        room_count:
+          type: int
+          not_null: true
+          default: 1
+    rule: >
+      shop_id 単位で、同一時間帯の “blocking statuses” の予約数が room_count を超えない。
+    overlap_definition: >
+      半開区間: start_at < other.end_at AND other.start_at < end_at
+    indexes_plan:
+      - guest_reservations(shop_id, status, start_at)
+      - guest_reservations(shop_id, status, end_at)

--- a/osakamenesu/specs/reservations/holds.yaml
+++ b/osakamenesu/specs/reservations/holds.yaml
@@ -1,0 +1,72 @@
+info:
+  id: reservations.holds
+  title: Holds (TTL) / reserved-expired semantics (P1 plan)
+  summary: >
+    予約作成の「仮押さえ(hold)」を導入するための最小仕様（計画）。
+    P0（営業時間 + server-computed end_at）の上に、安全に積める形にする。
+  status: planning-only
+
+links:
+  - spec: specs/reservations/core.yaml
+  - spec: specs/availability/core.yaml
+
+entities:
+  GuestReservation:
+    current_statuses: [draft, pending, confirmed, cancelled, no_show]
+    p1_statuses_add: [reserved, expired]
+    p1_fields_add:
+      reserved_until: { type: string, format: date-time, nullable: true }
+      idempotency_key: { type: string, nullable: true }
+
+rules:
+  ttl_hold:
+    status: reserved
+    ttl_minutes: 15
+    starts_at: created_at
+    ends_at_field: reserved_until
+    expiry:
+      - now >= reserved_until の場合、reserved は expired として扱う
+      - expiry は read 時に deterministic に効かせる（見え方がブレない）
+      - cleanup（非同期）は best-effort（負荷/遅延で多少遅れても read が正）
+
+  idempotency:
+    header: Idempotency-Key
+    expectations:
+      - 同一 key + 同一 payload + TTL 内は同一 hold を返す
+      - 同一 key + payload 不一致は client error
+
+  availability_blocking:
+    current_blocks: [pending, confirmed]
+    current_non_blocks: [draft, cancelled, no_show]
+    p1_blocks_add: [reserved]
+    p1_non_blocks_add: [expired]
+
+api_contract_draft:
+  note: >
+    計画のみ。実装では既存 /api/guest/reservations 互換を維持しつつ導入する。
+  candidates:
+    - id: reservations.hold
+      method: POST
+      path: /api/guest/reservations/hold
+      headers:
+        - Idempotency-Key
+      body:
+        shop_id: uuid
+        therapist_id: uuid
+        start_at: string (date-time)
+        duration_minutes: int
+        planned_extension_minutes: int
+      response:
+        status: reserved
+        reserved_until: string (date-time)
+    - id: reservations.confirm
+      method: POST
+      path: /api/guest/reservations/{id}/confirm
+      response:
+        status: confirmed
+
+out_of_scope:
+  - payments flow
+  - room_id assignment
+  - EXCLUDE USING gist constraints
+  - final concurrency strategy


### PR DESCRIPTION
## Summary
P1の最小スライス（hold TTL / reserved-expired / room_count / locking）を「実装なし」で棚卸し・spec化し、次PRで迷わない状態にします。

## Current state (facts)
- Status定義:
  - Shop-side: `pending/confirmed/declined/cancelled/expired` (`osakamenesu/services/api/app/enums.py`)
  - Guest: `draft/pending/confirmed/cancelled/no_show` (`osakamenesu/services/api/app/enums.py`)
- Availabilityをブロックするstatus:
  - `ACTIVE_RESERVATION_STATUSES = ("pending", "confirmed")` (`osakamenesu/services/api/app/domains/site/therapist_availability.py`)
- Locking:
  - `has_overlapping_reservation(..., lock=True)` が `GuestReservation` クエリに `SELECT ... FOR UPDATE` を付与（DBが対応している場合）
  - `guest_reservations.create` は `is_available(..., lock=True)` を使う（同上）
  - `osakamenesu/services/api/app` 配下に advisory lock は未検出（grep: advisory）

## Specs / Docs (planning only)
- `osakamenesu/specs/reservations/holds.yaml`
  - P1: `reserved`(hold) / `expired` 追加、TTLとIdempotency-Key期待値、availability blockingへの影響
- `osakamenesu/specs/availability/core.yaml`
  - P1追記: reserved/expired のblocking扱い、room_countの意味（設計のみ）
- `osakamenesu/docs/p1-hold-room-lock-plan.md`
  - 影響範囲の棚卸し＋Slice順（Slice1: hold/TTL → Slice2: room_count → Slice3: 強い排他）＋テスト計画

## Checks
- `cd osakamenesu/services/api && pytest -q` (no code changes)
