### PR TITLE
feat: P1 reservation hold (reserved/expired + TTL) [slice1]

### DIFF
--- a/osakamenesu/services/api/alembic/versions/0043_add_guest_reservation_hold_fields.py
+++ b/osakamenesu/services/api/alembic/versions/0043_add_guest_reservation_hold_fields.py
@@ -1,0 +1,63 @@
+"""add hold fields to guest_reservations
+
+Revision ID: 0043_add_guest_reservation_hold_fields
+Revises: 0042_add_guest_reservation_timing_columns
+Create Date: 2025-12-14
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0043_add_guest_reservation_hold_fields"
+down_revision = "0042_add_guest_reservation_timing_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Postgres enum values are append-only. Add new values idempotently.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TYPE guest_reservation_status ADD VALUE 'reserved';
+        EXCEPTION WHEN duplicate_object THEN NULL; END$$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TYPE guest_reservation_status ADD VALUE 'expired';
+        EXCEPTION WHEN duplicate_object THEN NULL; END$$;
+        """
+    )
+
+    op.add_column(
+        "guest_reservations",
+        sa.Column("reserved_until", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "guest_reservations",
+        sa.Column("idempotency_key", sa.String(length=255), nullable=True),
+    )
+    op.create_index(
+        "ux_guest_reservations_idempotency_key",
+        "guest_reservations",
+        ["idempotency_key"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_guest_reservations_idempotency_key",
+        table_name="guest_reservations",
+    )
+    op.drop_column("guest_reservations", "idempotency_key")
+    op.drop_column("guest_reservations", "reserved_until")
+    # NOTE: Postgres enum values cannot be removed safely in a downgrade.

--- a/osakamenesu/services/api/app/domains/site/services/shop/search_service.py
+++ b/osakamenesu/services/api/app/domains/site/services/shop/search_service.py
@@ -283,7 +283,8 @@ async def _derive_next_availability_from_slots_sot(
     if not unique_ids:
         return {}
 
-    today = now_jst().date()
+    now = now_jst()
+    today = now.date()
     end_date = today + timedelta(days=lookahead_days)
 
     # 1) buffer_minutes per therapist (Profile.buffer_minutes). Missing => 0.
@@ -325,6 +326,7 @@ async def _derive_next_availability_from_slots_sot(
         models.GuestReservation.end_at > range_start,
     )
     reservations = list((await db.execute(reservations_stmt)).scalars().all())
+    reservations = sot._filter_active_reservations(reservations, now)
     reservations_by_therapist: dict[UUID, list[models.GuestReservation]] = defaultdict(
         list
     )

--- a/osakamenesu/services/api/app/enums.py
+++ b/osakamenesu/services/api/app/enums.py
@@ -113,9 +113,11 @@ GUEST_RESERVATION_STATUS_VALUES: Tuple[str, ...] = (
     "confirmed",
     "cancelled",
     "no_show",
+    "reserved",
+    "expired",
 )
 GuestReservationStatusLiteral = Literal[
-    "draft", "pending", "confirmed", "cancelled", "no_show"
+    "draft", "pending", "confirmed", "cancelled", "no_show", "reserved", "expired"
 ]
 
 

--- a/osakamenesu/services/api/app/models.py
+++ b/osakamenesu/services/api/app/models.py
@@ -932,6 +932,10 @@ class GuestReservation(Base):
     buffer_minutes: Mapped[int] = mapped_column(
         Integer, default=0, nullable=False, server_default="0"
     )
+    reserved_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    idempotency_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
     course_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True
     )

--- a/osakamenesu/services/api/app/tests/test_guest_reservations_hold.py
+++ b/osakamenesu/services/api/app/tests/test_guest_reservations_hold.py
@@ -1,0 +1,212 @@
+import os
+
+# DATABASE_URL を asyncpg に固定してから app.* を import する
+os.environ["DATABASE_URL"] = "postgresql+asyncpg://app:app@localhost:5432/osaka_menesu"
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.domains.site import guest_reservations as domain
+from app.domains.site.guest_reservations import create_guest_reservation_hold
+from app.domains.site import therapist_availability as availability
+from app.models import GuestReservation
+
+
+def _ts(hour: int, minute: int = 0) -> datetime:
+    return datetime(2025, 1, 1, hour, minute, 0, tzinfo=timezone.utc)
+
+
+class _ScalarResult:
+    def __init__(self, scalar_value=None):
+        self._scalar_value = scalar_value
+
+    def scalar_one_or_none(self):
+        return self._scalar_value
+
+
+class _Scalars:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+
+class _ScalarsResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return _Scalars(self._items)
+
+
+class StubSession:
+    def __init__(self):
+        self.items: list[GuestReservation] = []
+        self.by_idempotency_key: dict[str, GuestReservation] = {}
+
+    async def execute(self, stmt):
+        entity = stmt.column_descriptions[0]["entity"]
+        if entity is GuestReservation:
+            try:
+                criteria = list(getattr(stmt, "_where_criteria", []))
+            except Exception:
+                criteria = []
+            for crit in criteria:
+                left = getattr(crit, "left", None)
+                if getattr(left, "name", None) != "idempotency_key":
+                    continue
+                right = getattr(crit, "right", None)
+                key = getattr(right, "value", None)
+                if key is None:
+                    continue
+                return _ScalarResult(self.by_idempotency_key.get(str(key)))
+        return _ScalarResult(None)
+
+    def add(self, obj):
+        if isinstance(obj, GuestReservation):
+            self.items.append(obj)
+            if obj.idempotency_key:
+                self.by_idempotency_key[str(obj.idempotency_key)] = obj
+
+    async def commit(self):
+        return None
+
+    async def refresh(self, obj):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_hold_idempotency_returns_same_reservation(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def _avail(db, therapist_id, start_at, end_at, lock=False):
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "is_available", _avail)
+
+    session = StubSession()
+    now = _ts(12)
+    payload = {
+        "shop_id": uuid4(),
+        "therapist_id": uuid4(),
+        "start_at": _ts(14),
+        "duration_minutes": 60,
+        "planned_extension_minutes": 0,
+    }
+
+    res1, debug1, err1 = await create_guest_reservation_hold(
+        session, payload, idempotency_key="k1", now=now
+    )
+    assert err1 is None
+    assert debug1 == {}
+    assert res1 is not None
+    assert str(res1.status) == "reserved"
+    assert res1.reserved_until == now + timedelta(minutes=domain.HOLD_TTL_MINUTES)
+    assert len(session.items) == 1
+
+    res2, debug2, err2 = await create_guest_reservation_hold(
+        session, payload, idempotency_key="k1", now=now
+    )
+    assert err2 is None
+    assert debug2 == {}
+    assert res2 is res1
+    assert len(session.items) == 1
+
+
+@pytest.mark.asyncio
+async def test_hold_idempotency_conflict(monkeypatch: pytest.MonkeyPatch):
+    async def _avail(db, therapist_id, start_at, end_at, lock=False):
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "is_available", _avail)
+
+    session = StubSession()
+    now = _ts(12)
+    payload = {
+        "shop_id": uuid4(),
+        "therapist_id": uuid4(),
+        "start_at": _ts(14),
+        "duration_minutes": 60,
+        "planned_extension_minutes": 0,
+    }
+    res1, debug1, err1 = await create_guest_reservation_hold(
+        session, payload, idempotency_key="k2", now=now
+    )
+    assert err1 is None
+    assert debug1 == {}
+    assert res1 is not None
+
+    conflict_payload = dict(payload)
+    conflict_payload["duration_minutes"] = 90
+    res2, debug2, err2 = await create_guest_reservation_hold(
+        session, conflict_payload, idempotency_key="k2", now=now
+    )
+    assert res2 is None
+    assert err2 == "idempotency_key_conflict"
+    assert "idempotency_key_conflict" in debug2.get("rejected_reasons", [])
+
+
+@pytest.mark.asyncio
+async def test_reserved_blocks_and_expired_does_not():
+    therapist_id = uuid4()
+
+    # NOTE: availability.has_overlapping_reservation fetches reservations via db.execute(),
+    # so we provide a tiny session stub per case.
+    class DummySession:
+        def __init__(self, reservations):
+            self._reservations = reservations
+
+        async def execute(self, stmt):
+            return _ScalarsResult(self._reservations)
+
+    now = datetime.now(timezone.utc)
+    start_at = now + timedelta(days=1)
+    end_at = start_at + timedelta(hours=1)
+
+    active_hold = GuestReservation(
+        shop_id=uuid4(),
+        therapist_id=therapist_id,
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="reserved",
+        reserved_until=now + timedelta(minutes=10),
+    )
+    expired_hold = GuestReservation(
+        shop_id=uuid4(),
+        therapist_id=therapist_id,
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="reserved",
+        reserved_until=now - timedelta(minutes=10),
+    )
+
+    assert (
+        await availability.has_overlapping_reservation(
+            DummySession([active_hold]),
+            therapist_id,
+            start_at,
+            end_at,
+        )
+        is True
+    )
+    assert (
+        await availability.has_overlapping_reservation(
+            DummySession([expired_hold]),
+            therapist_id,
+            start_at,
+            end_at,
+        )
+        is False
+    )


### PR DESCRIPTION
## 目的
P1 Slice1として、ゲスト予約の仮押さえ(hold/TTL)を最小差分で導入します。

## 変更概要
- GuestReservation status に `reserved` / `expired` を追加
- DB: `guest_reservations` に以下を追加
  - `reserved_until` (timestamptz, nullable)
  - `idempotency_key` (text, nullable) + unique index
- 新規エンドポイント: `POST /api/guest/reservations/hold`
  - `Idempotency-Key` ヘッダ必須
  - 成功時: status=`reserved` + `reserved_until` を返却
  - 同一 key + 同一 payload は同一 hold を返す
  - 同一 key + payload 不一致は 400 `idempotency_key_conflict`
- Availability blocking:
  - `reserved` は `reserved_until > now` の間のみ `pending/confirmed` と同様にブロック
  - `reserved_until <= now` はブロックしない（lazy expiry）

## 仕様
- `specs/reservations/holds.yaml`（planning-only）に沿った実装です。

## テスト
- `services/api/app/tests/test_guest_reservations_hold.py`
  - idempotency (same key returns same reservation / conflict)
  - reserved がブロックし、期限切れはブロックしない

## TODO（Slice1の範囲外）
- scheduler/cron による expired へのクリーンアップ
- confirm エンドポイント（reserved→confirmed）
- room_count 制約
