### PR TITLE
feat: expire reserved holds via ops job (Slice2a)

### DIFF
--- a/osakamenesu/services/api/app/services/reservation_holds.py
+++ b/osakamenesu/services/api/app/services/reservation_holds.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import GuestReservation
+
+logger = logging.getLogger(__name__)
+
+# NOTE:
+# `HOLD_TTL_MINUTES` is currently defined in `app.domains.site.guest_reservations`.
+# This constant is used only as a defensive fallback when `reserved_until` is NULL.
+DEFAULT_HOLD_TTL_MINUTES = 15
+
+
+def _status_value(reservation: GuestReservation) -> str:
+    value = reservation.status
+    if hasattr(value, "value"):
+        value = value.value
+    return str(value)
+
+
+def _should_expire_hold(
+    reservation: GuestReservation,
+    *,
+    now: datetime,
+    ttl_minutes: int,
+) -> bool:
+    if _status_value(reservation) != "reserved":
+        return False
+
+    reserved_until = getattr(reservation, "reserved_until", None)
+    if reserved_until is not None:
+        return reserved_until <= now
+
+    created_at = getattr(reservation, "created_at", None)
+    if created_at is None:
+        return False
+
+    cutoff = now - timedelta(minutes=ttl_minutes)
+    return created_at <= cutoff
+
+
+async def expire_reserved_holds(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    ttl_minutes: int = DEFAULT_HOLD_TTL_MINUTES,
+    limit: int = 1000,
+) -> int:
+    """Expire GuestReservation holds (status=reserved) past TTL.
+
+    - Normal path: `reserved_until <= now` -> status=expired
+    - Defensive: `reserved_until IS NULL` -> expire when `created_at <= now - ttl`
+
+    Caller is responsible for committing the transaction.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(minutes=ttl_minutes)
+
+    stmt = (
+        select(GuestReservation)
+        .where(GuestReservation.status == "reserved")
+        .where(
+            or_(
+                and_(
+                    GuestReservation.reserved_until.is_not(None),
+                    GuestReservation.reserved_until <= now,
+                ),
+                and_(
+                    GuestReservation.reserved_until.is_(None),
+                    GuestReservation.created_at <= cutoff,
+                ),
+            )
+        )
+        .limit(limit)
+    )
+    res = await db.execute(stmt)
+    reservations = list(res.scalars().all())
+
+    expired: list[GuestReservation] = []
+    for reservation in reservations:
+        if not _should_expire_hold(reservation, now=now, ttl_minutes=ttl_minutes):
+            continue
+        reservation.status = "expired"
+        reservation.updated_at = now
+        expired.append(reservation)
+
+    if expired:
+        logger.info(
+            "expire_reserved_holds: expired=%s ttl_minutes=%s limit=%s",
+            len(expired),
+            ttl_minutes,
+            limit,
+        )
+
+    return len(expired)

--- a/osakamenesu/services/api/app/tests/test_reservation_holds_cleanup.py
+++ b/osakamenesu/services/api/app/tests/test_reservation_holds_cleanup.py
@@ -1,0 +1,131 @@
+import os
+
+# DATABASE_URL を asyncpg に固定してから app.* を import する
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql+asyncpg://app:app@localhost:5432/osaka_menesu"
+)
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.domains.site import therapist_availability as availability
+from app.models import GuestReservation
+from app.services.reservation_holds import expire_reserved_holds
+
+
+class _Scalars:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+
+class _ScalarsResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return _Scalars(self._items)
+
+
+class DummySession:
+    def __init__(self, reservations):
+        self._reservations = reservations
+
+    async def execute(self, stmt):  # noqa: ARG002 - statement is not evaluated in this unit test
+        return _ScalarsResult(self._reservations)
+
+
+@pytest.mark.asyncio
+async def test_expire_reserved_holds_defensive_null_reserved_until_unblocks():
+    therapist_id = uuid4()
+    now = datetime.now(timezone.utc)
+    start_at = now + timedelta(days=1)
+    end_at = start_at + timedelta(hours=1)
+
+    # reserved_until が NULL の hold はブロックし続ける可能性があるため、
+    # TTL経過時に defensive に expired へ落とす。
+    hold = GuestReservation(
+        id=uuid4(),
+        shop_id=uuid4(),
+        therapist_id=therapist_id,
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="reserved",
+        reserved_until=None,
+        created_at=now - timedelta(minutes=30),
+        updated_at=now - timedelta(minutes=30),
+    )
+    session = DummySession([hold])
+
+    assert (
+        await availability.has_overlapping_reservation(
+            session,
+            therapist_id,
+            start_at,
+            end_at,
+        )
+        is True
+    )
+
+    expired = await expire_reserved_holds(session, now=now, ttl_minutes=15)
+    assert expired == 1
+    assert hold.status == "expired"
+
+    assert (
+        await availability.has_overlapping_reservation(
+            session,
+            therapist_id,
+            start_at,
+            end_at,
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_expire_reserved_holds_expires_only_past_reserved_until():
+    now = datetime.now(timezone.utc)
+    start_at = now + timedelta(days=1)
+    end_at = start_at + timedelta(hours=1)
+
+    expired_hold = GuestReservation(
+        id=uuid4(),
+        shop_id=uuid4(),
+        therapist_id=uuid4(),
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="reserved",
+        reserved_until=now - timedelta(minutes=1),
+        created_at=now - timedelta(minutes=30),
+        updated_at=now - timedelta(minutes=30),
+    )
+    active_hold = GuestReservation(
+        id=uuid4(),
+        shop_id=uuid4(),
+        therapist_id=uuid4(),
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="reserved",
+        reserved_until=now + timedelta(minutes=10),
+        created_at=now - timedelta(minutes=1),
+        updated_at=now - timedelta(minutes=1),
+    )
+
+    session = DummySession([expired_hold, active_hold])
+    expired = await expire_reserved_holds(session, now=now, ttl_minutes=15)
+    assert expired == 1
+    assert expired_hold.status == "expired"
+    assert active_hold.status == "reserved"


### PR DESCRIPTION
## Slice2 scope
Slice2a（TTL cleanup）を先に入れます。`reserved_until` を持つ hold の期限切れをDB上で `expired` に落として、状態が永続的にズレないようにします（room_countは次スライス）。

## 変更概要
- `services/api/app/services/reservation_holds.py`: 期限切れの hold（status=reserved）を `expired` に更新する `expire_reserved_holds()` を追加
  - 通常: `reserved_until <= now` を expired 化
  - 防御: `reserved_until IS NULL` かつ `created_at` がTTL超過の場合も expired 化（無限ブロック回避）
- `services/api/app/domains/ops/router.py`: `POST /api/ops/reservations/expire_holds` を追加（ops tokenがあればBearerで保護）
- Tests: cleanupが動くこと＋reserved_until NULLケースが expired 化されて availability のブロックが外れること

## Why TTL cleanup first?
Slice1はlazy expiryで動作は成立していますが、DB上のstatusが `reserved` のまま残ると運用/診断が難しくなります。まずcleanupの“実行手段”を用意してから、room_countへ進むのが安全です。

## 検証
- `cd osakamenesu/services/api && pytest -q`（ローカル）
