### PR TITLE
chore: operationalize expire_holds (docs + auth test + cron)

### DIFF
--- a/.github/workflows/expire_holds_cron.yml
+++ b/.github/workflows/expire_holds_cron.yml
@@ -1,0 +1,40 @@
+name: expire_holds cron
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  expire-holds-prod:
+    name: ops: expire_holds (prod)
+    runs-on: ubuntu-latest
+    if: ${{ secrets.OPS_TOKEN_PROD != '' }}
+    concurrency:
+      group: expire_holds-prod
+      cancel-in-progress: true
+    steps:
+      - name: Call expire_holds (prod)
+        env:
+          API_BASE: https://api.osakamenesu.com
+          OPS_TOKEN: ${{ secrets.OPS_TOKEN_PROD }}
+        run: |
+          curl -fsS -X POST "$API_BASE/api/ops/reservations/expire_holds" \
+            -H "Authorization: Bearer $OPS_TOKEN"
+
+  expire-holds-stg:
+    name: ops: expire_holds (stg)
+    runs-on: ubuntu-latest
+    if: ${{ secrets.OPS_TOKEN_STG != '' }}
+    concurrency:
+      group: expire_holds-stg
+      cancel-in-progress: true
+    steps:
+      - name: Call expire_holds (stg)
+        env:
+          API_BASE: https://osakamenesu-api-stg.fly.dev
+          OPS_TOKEN: ${{ secrets.OPS_TOKEN_STG }}
+        run: |
+          curl -fsS -X POST "$API_BASE/api/ops/reservations/expire_holds" \
+            -H "Authorization: Bearer $OPS_TOKEN"
+

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -336,6 +336,38 @@ curl -i -sS -X POST \"$BASE/api/guest/reservations\" \\
 - 結果: POST#1 で `status=reserved` 作成、POST#2（同key+同payload）で同じ `reservation_id` が返り idempotent
 - 証跡: https://github.com/yusaku0324/kakeru/pull/212#issuecomment-3652117628
 
+## expire_holds（STG/PROD）
+
+目的: `reserved_until` を過ぎた hold（`status=reserved`）を `expired` に確定させ、DB上の状態を運用可能にする。
+
+### STG smoke evidence
+
+- reservation_id: `0f2418fb-f2ee-447d-82a7-54c509bf9e35`
+- hold後: `availability_summary.has_available=false`
+- `POST /api/ops/reservations/expire_holds` 後:
+  - `status=expired`
+  - `availability_summary.has_available=true`
+
+### 実行例（STG）
+
+```bash
+curl -fsS -X POST 'https://osakamenesu-api-stg.fly.dev/api/ops/reservations/expire_holds' \
+  -H "Authorization: Bearer $OPS_TOKEN_STG"
+```
+
+### 実行例（PROD）
+
+```bash
+curl -fsS -X POST 'https://api.osakamenesu.com/api/ops/reservations/expire_holds' \
+  -H "Authorization: Bearer $OPS_TOKEN_PROD"
+```
+
+### Ops token
+
+- 環境変数: `OPS_API_TOKEN`（未設定の場合は ops endpoint が開放される）
+- Header: `Authorization: Bearer <token>`
+- 失敗時: `401 ops_token_required` / `401 ops_token_invalid`
+
 ## 破棄手順（記載のみ・今は実行しない）
 
 ```bash

--- a/osakamenesu/services/api/app/tests/test_ops_expire_holds_auth.py
+++ b/osakamenesu/services/api/app/tests/test_ops_expire_holds_auth.py
@@ -1,0 +1,61 @@
+import os
+
+# DATABASE_URL を asyncpg に固定してから app.* を import する
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql+asyncpg://app:app@localhost:5432/osaka_menesu"
+)
+
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ops_router_module = importlib.import_module("app.domains.ops.router")
+from app.db import get_session
+from app.domains.ops.router import router as ops_router
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    app = FastAPI()
+    app.include_router(ops_router)
+
+    async def _fake_session():
+        class DummySession:
+            async def commit(self):
+                return None
+
+        yield DummySession()
+
+    app.dependency_overrides[get_session] = _fake_session
+
+    async def _fake_expire(db, now=None, ttl_minutes=15, limit=1000):  # noqa: ARG001
+        return 0
+
+    monkeypatch.setattr(ops_router_module, "expire_reserved_holds", _fake_expire)
+    return TestClient(app)
+
+
+def test_expire_holds_requires_ops_token_when_configured(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+):
+    monkeypatch.setattr(ops_router_module.settings, "ops_api_token", "secret-token")
+
+    res = client.post("/api/ops/reservations/expire_holds")
+    assert res.status_code == 401
+    assert res.json()["detail"] == "ops_token_required"
+
+    res = client.post(
+        "/api/ops/reservations/expire_holds",
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert res.status_code == 401
+    assert res.json()["detail"] == "ops_token_invalid"
+
+    res = client.post(
+        "/api/ops/reservations/expire_holds",
+        headers={"Authorization": "Bearer secret-token"},
+    )
+    assert res.status_code == 200
+    assert res.json()["expired"] == 0


### PR DESCRIPTION
## 変更概要
- `docs/staging.md` に `expire_holds` の目的・実行手順（STG/PROD curl例）・STGスモーク証跡（reservation_id等）を追記
- `/api/ops/reservations/expire_holds` の認証（OPSトークン）回帰テストを追加（トークン設定時のみ必須・未設定時は従来通り）
- 定期実行用の GitHub Actions を追加（`/.github/workflows/expire_holds_cron.yml`）
  - 30分おき + `workflow_dispatch`
  - `OPS_TOKEN_PROD` / `OPS_TOKEN_STG` が未設定ならスキップ
  - concurrency で多重実行防止

## メモ（マージ後の手動作業）
- GitHub Secrets に `OPS_TOKEN_PROD` / `OPS_TOKEN_STG` を追加すると cron が有効化されます（未設定なら安全にスキップ）

## 影響範囲
- production code 変更なし（docs + test + workflow のみ）