### PR TITLE
fix(ci): make expire_holds_cron dispatchable

### DIFF
--- a/.github/workflows/expire_holds_cron.yml
+++ b/.github/workflows/expire_holds_cron.yml
@@ -7,34 +7,41 @@ on:
 
 jobs:
   expire-holds-prod:
-    name: ops: expire_holds (prod)
+    name: "ops: expire_holds (prod)"
     runs-on: ubuntu-latest
-    if: ${{ secrets.OPS_TOKEN_PROD != '' }}
+    env:
+      API_BASE: https://api.osakamenesu.com
+      OPS_TOKEN: ${{ secrets.OPS_TOKEN_PROD }}
     concurrency:
       group: expire_holds-prod
       cancel-in-progress: true
     steps:
+      - name: Skip (OPS_TOKEN_PROD missing)
+        if: ${{ env.OPS_TOKEN == '' }}
+        run: echo "OPS_TOKEN_PROD is not set; skipping."
+
       - name: Call expire_holds (prod)
-        env:
-          API_BASE: https://api.osakamenesu.com
-          OPS_TOKEN: ${{ secrets.OPS_TOKEN_PROD }}
+        if: ${{ env.OPS_TOKEN != '' }}
         run: |
           curl -fsS -X POST "$API_BASE/api/ops/reservations/expire_holds" \
             -H "Authorization: Bearer $OPS_TOKEN"
 
   expire-holds-stg:
-    name: ops: expire_holds (stg)
+    name: "ops: expire_holds (stg)"
     runs-on: ubuntu-latest
-    if: ${{ secrets.OPS_TOKEN_STG != '' }}
+    env:
+      API_BASE: https://osakamenesu-api-stg.fly.dev
+      OPS_TOKEN: ${{ secrets.OPS_TOKEN_STG }}
     concurrency:
       group: expire_holds-stg
       cancel-in-progress: true
     steps:
+      - name: Skip (OPS_TOKEN_STG missing)
+        if: ${{ env.OPS_TOKEN == '' }}
+        run: echo "OPS_TOKEN_STG is not set; skipping."
+
       - name: Call expire_holds (stg)
-        env:
-          API_BASE: https://osakamenesu-api-stg.fly.dev
-          OPS_TOKEN: ${{ secrets.OPS_TOKEN_STG }}
+        if: ${{ env.OPS_TOKEN != '' }}
         run: |
           curl -fsS -X POST "$API_BASE/api/ops/reservations/expire_holds" \
             -H "Authorization: Bearer $OPS_TOKEN"
-


### PR DESCRIPTION
## 背景
`expire_holds_cron.yml` が無効扱いになり、workflow_dispatch も効かず Actions 上で即失敗していました。

## 修正
- job名の `ops: ...` をクォートして YAML を正しくパース可能に
- `jobs.<job>.if` で `secrets.*` を参照せず、step側でトークン未設定時はスキップする形に変更

## 確認
- `actionlint .github/workflows/expire_holds_cron.yml` が通ることを確認済み

※ 既に `OPS_TOKEN_PROD` / `OPS_TOKEN_STG` は設定済みのため、マージ後に `Run workflow` で手動実行→初回成功確認まで行えます。