### PR TITLE
chore: stabilize STG E2E + add rollback regression guard

### DIFF
--- a/.github/workflows/e2e_shift_reservation_flow.yml
+++ b/.github/workflows/e2e_shift_reservation_flow.yml
@@ -1,0 +1,92 @@
+name: E2E (STG) shift -> search -> reservation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-shift-reservation-flow
+  cancel-in-progress: false
+
+jobs:
+  e2e-shift-reservation-flow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Use Preview env secrets synced from Doppler (if configured).
+    environment: Preview
+    if: ${{ secrets.E2E_ADMIN_KEY != '' }}
+    defaults:
+      run:
+        working-directory: osakamenesu
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
+      NEXT_PUBLIC_OSAKAMENESU_API_BASE: https://osakamenesu-api-stg.fly.dev
+      OSAKAMENESU_API_INTERNAL_BASE: https://osakamenesu-api-stg.fly.dev
+      E2E_WEB_BASE: http://127.0.0.1:3000
+      E2E_API_BASE: https://osakamenesu-api-stg.fly.dev
+      E2E_ADMIN_BASE: https://osakamenesu-api-stg.fly.dev
+      E2E_ADMIN_KEY: ${{ secrets.E2E_ADMIN_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers (Chromium)
+        run: |
+          rm -rf ~/.cache/ms-playwright apps/web/node_modules/.cache/ms-playwright
+          PLAYWRIGHT_BROWSERS_PATH="$HOME/.cache/ms-playwright" pnpm --dir apps/web exec playwright install --with-deps chromium
+
+      - name: Start web (dev server)
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/web dev > /tmp/web.log 2>&1 &
+          echo $! > /tmp/web.pid
+          for i in {1..60}; do
+            if curl -sSf "http://127.0.0.1:3000/" >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Web dev server failed to start"
+          tail -n 200 /tmp/web.log || true
+          exit 1
+
+      - name: Run Playwright (single spec)
+        run: |
+          pnpm --dir apps/web exec playwright test e2e/shift_reservation_flow.spec.ts --reporter=line --timeout=120000
+
+      - name: Stop web (dev server)
+        if: always()
+        run: |
+          if [ -f /tmp/web.pid ]; then
+            kill "$(cat /tmp/web.pid)" || true
+          fi
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-shift-reservation-flow
+          path: |
+            osakamenesu/apps/web/playwright-report/
+            osakamenesu/apps/web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/osakamenesu/services/api/app/tests/test_guest_reservations_rollback.py
+++ b/osakamenesu/services/api/app/tests/test_guest_reservations_rollback.py
@@ -1,0 +1,83 @@
+import os
+
+# DATABASE_URL を asyncpg に固定してから app.* を import する
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql+asyncpg://app:app@localhost:5432/osaka_menesu"
+)
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.domains.site import guest_reservations as domain
+from app.domains.site.guest_reservations import (
+    _try_fetch_profile,
+    assign_for_free,
+    create_guest_reservation_hold,
+)
+
+
+class RollbackSpySession:
+    def __init__(self):
+        self.rollback_calls = 0
+
+    async def execute(self, _stmt):
+        raise RuntimeError("boom")
+
+    async def rollback(self):
+        self.rollback_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_try_fetch_profile_rolls_back_on_execute_error():
+    session = RollbackSpySession()
+    res = await _try_fetch_profile(session, uuid4())
+    assert res is None
+    assert session.rollback_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_assign_for_free_rolls_back_on_execute_error():
+    session = RollbackSpySession()
+    shop_id = uuid4()
+    start_at = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+    end_at = start_at + timedelta(minutes=60)
+
+    therapist_id, debug = await assign_for_free(
+        session, shop_id, start_at, end_at, base_staff_id=None
+    )
+    assert therapist_id is None
+    assert debug.get("rejected_reasons") == ["internal_error"]
+    assert session.rollback_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_hold_rolls_back_on_idempotency_lookup_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def _avail(_db, _therapist_id, _start_at, _end_at, lock=False):
+        return False, {"rejected_reasons": ["no_shift"]}
+
+    monkeypatch.setattr(domain, "is_available", _avail)
+
+    session = RollbackSpySession()
+    now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+    start_at = now + timedelta(days=2)
+
+    res, debug, err = await create_guest_reservation_hold(
+        session,
+        {
+            "shop_id": "not-a-uuid",  # avoid profile DB lookup (focus on idempotency execute)
+            "therapist_id": uuid4(),
+            "start_at": start_at,
+            "duration_minutes": 60,
+            "planned_extension_minutes": 0,
+        },
+        idempotency_key="k-rollback",
+        now=now,
+    )
+    assert err is None
+    assert res is None
+    assert "no_shift" in (debug.get("rejected_reasons") or [])
+    assert session.rollback_calls == 1


### PR DESCRIPTION
## 目的
STG長期運用で出やすい pending-rollback 起因の internal_error と、同一 start_at 再利用によるE2E不安定化を再発しにくくする。

## 変更点
- API: rollback best-effort の回帰テスト追加（DB例外を握りつぶす経路でも rollback() が呼ばれることを固定）
- Web E2E: start_at 候補の選択をローテーションして重複に強化 + cancel を try/finally で必ず実行
- Actions: workflow_dispatch のみの STG E2E（push/PRでは走らない）を追加
  - secrets: Environment=Preview に `E2E_ADMIN_KEY` が必要（未設定ならジョブskip）

## 動作確認
- lefthook pre-commit（ruff/pytest/tsc/eslint）

## 手動実行（GitHub Actions）
- Workflow: `E2E (STG) shift -> search -> reservation`
- STGにのみPOSTする（test側でも STG以外は skip）
