### PR TITLE
feat: P1 room_count (limit overlapping reservations per shop)

### DIFF
--- a/osakamenesu/services/api/alembic/versions/0044_add_profile_room_count.py
+++ b/osakamenesu/services/api/alembic/versions/0044_add_profile_room_count.py
@@ -1,0 +1,34 @@
+"""add room_count to profiles
+
+Revision ID: 0044_add_profile_room_count
+Revises: 0043_add_guest_reservation_hold_fields
+Create Date: 2025-12-15
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0044_add_profile_room_count"
+down_revision = "0043_add_guest_reservation_hold_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "profiles",
+        sa.Column(
+            "room_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("profiles", "room_count")

--- a/osakamenesu/services/api/app/models.py
+++ b/osakamenesu/services/api/app/models.py
@@ -109,6 +109,13 @@ class Profile(Base):
     buffer_minutes: Mapped[int] = mapped_column(
         Integer, default=0, nullable=False, server_default="0"
     )
+    room_count: Mapped[int] = mapped_column(
+        Integer,
+        default=1,
+        nullable=False,
+        server_default="1",
+        comment="Max number of overlapping active guest reservations allowed per shop",
+    )
     default_slot_duration_minutes: Mapped[int | None] = mapped_column(
         Integer,
         nullable=True,

--- a/osakamenesu/services/api/app/tests/test_guest_reservations_room_count.py
+++ b/osakamenesu/services/api/app/tests/test_guest_reservations_room_count.py
@@ -1,0 +1,285 @@
+import os
+
+# DATABASE_URL を asyncpg に固定してから app.* を import する
+os.environ["DATABASE_URL"] = "postgresql+asyncpg://app:app@localhost:5432/osaka_menesu"
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.domains.site import guest_reservations as domain
+from app.domains.site.guest_reservations import (
+    create_guest_reservation,
+    create_guest_reservation_hold,
+)
+from app.models import GuestReservation
+
+
+def _ts(hour: int, minute: int = 0) -> datetime:
+    return datetime(2025, 1, 1, hour, minute, 0, tzinfo=timezone.utc)
+
+
+class _ScalarResult:
+    def __init__(self, scalar_value=None):
+        self._scalar_value = scalar_value
+
+    def scalar_one_or_none(self):
+        return self._scalar_value
+
+
+class _Scalars:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+
+class _ScalarsResult:
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return _Scalars(self._items)
+
+
+class CreateSession:
+    def __init__(self, reservations):
+        self._reservations = reservations
+        self.items: list[GuestReservation] = []
+
+    async def execute(self, stmt):
+        entity = stmt.column_descriptions[0]["entity"]
+        if entity is GuestReservation:
+            return _ScalarsResult(self._reservations)
+        return _ScalarResult(None)
+
+    def add(self, obj):
+        if isinstance(obj, GuestReservation):
+            self.items.append(obj)
+
+    async def commit(self):
+        return None
+
+    async def refresh(self, obj):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+class HoldSession(CreateSession):
+    async def execute(self, stmt):
+        entity = stmt.column_descriptions[0]["entity"]
+        if entity is GuestReservation:
+            criteria = list(getattr(stmt, "_where_criteria", []))
+            for crit in criteria:
+                left = getattr(crit, "left", None)
+                if getattr(left, "name", None) == "idempotency_key":
+                    return _ScalarResult(None)
+            return _ScalarsResult(self._reservations)
+        return _ScalarResult(None)
+
+
+@pytest.mark.asyncio
+async def test_room_count_one_blocks_cross_therapist_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    shop_id = uuid4()
+    therapist_a = uuid4()
+    therapist_b = uuid4()
+    now = _ts(10)
+    start_at = now + timedelta(hours=4)
+    end_at = start_at + timedelta(hours=1)
+
+    profile = SimpleNamespace(contact_json={}, room_count=1)
+
+    async def _fetch_profile(_db, _shop_id):
+        return profile
+
+    monkeypatch.setattr(domain, "_try_fetch_profile", _fetch_profile)
+
+    async def _avail(_db, _therapist_id, _start_at, _end_at, lock=False):
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "is_available", _avail)
+
+    existing = GuestReservation(
+        shop_id=shop_id,
+        therapist_id=therapist_a,
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="confirmed",
+    )
+
+    session = CreateSession([existing])
+    reservation, debug = await create_guest_reservation(
+        session,
+        {
+            "shop_id": shop_id,
+            "therapist_id": therapist_b,
+            "start_at": start_at,
+            "duration_minutes": 60,
+            "planned_extension_minutes": 0,
+        },
+        now=now,
+    )
+    assert reservation is None
+    assert "room_full" in (debug.get("rejected_reasons") or [])
+
+
+@pytest.mark.asyncio
+async def test_room_count_two_allows_second_overlap(monkeypatch: pytest.MonkeyPatch):
+    shop_id = uuid4()
+    therapist_a = uuid4()
+    therapist_b = uuid4()
+    now = _ts(10)
+    start_at = now + timedelta(hours=4)
+    end_at = start_at + timedelta(hours=1)
+
+    profile = SimpleNamespace(contact_json={}, room_count=2)
+
+    async def _fetch_profile(_db, _shop_id):
+        return profile
+
+    monkeypatch.setattr(domain, "_try_fetch_profile", _fetch_profile)
+
+    async def _avail(_db, _therapist_id, _start_at, _end_at, lock=False):
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "is_available", _avail)
+
+    existing = GuestReservation(
+        shop_id=shop_id,
+        therapist_id=therapist_a,
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="confirmed",
+    )
+
+    session = CreateSession([existing])
+    reservation, debug = await create_guest_reservation(
+        session,
+        {
+            "shop_id": shop_id,
+            "therapist_id": therapist_b,
+            "start_at": start_at,
+            "duration_minutes": 60,
+            "planned_extension_minutes": 0,
+        },
+        now=now,
+    )
+    assert reservation is not None
+    assert debug == {}
+
+
+@pytest.mark.asyncio
+async def test_reserved_hold_counts_toward_room_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    shop_id = uuid4()
+    therapist_a = uuid4()
+    therapist_b = uuid4()
+    now = _ts(10)
+    start_at = now + timedelta(hours=4)
+    end_at = start_at + timedelta(hours=1)
+
+    profile = SimpleNamespace(contact_json={}, room_count=1)
+
+    async def _fetch_profile(_db, _shop_id):
+        return profile
+
+    monkeypatch.setattr(domain, "_try_fetch_profile", _fetch_profile)
+
+    async def _avail(_db, _therapist_id, _start_at, _end_at, lock=False):
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "is_available", _avail)
+
+    active_hold = GuestReservation(
+        shop_id=shop_id,
+        therapist_id=therapist_a,
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="reserved",
+        reserved_until=now + timedelta(minutes=10),
+    )
+
+    session = HoldSession([active_hold])
+    reservation, debug, err = await create_guest_reservation_hold(
+        session,
+        {
+            "shop_id": shop_id,
+            "therapist_id": therapist_b,
+            "start_at": start_at,
+            "duration_minutes": 60,
+            "planned_extension_minutes": 0,
+        },
+        idempotency_key="k-room-full",
+        now=now,
+    )
+    assert err is None
+    assert reservation is None
+    assert "room_full" in (debug.get("rejected_reasons") or [])
+
+
+@pytest.mark.asyncio
+async def test_expired_reserved_hold_does_not_count(monkeypatch: pytest.MonkeyPatch):
+    shop_id = uuid4()
+    therapist_a = uuid4()
+    therapist_b = uuid4()
+    now = _ts(10)
+    start_at = now + timedelta(hours=4)
+    end_at = start_at + timedelta(hours=1)
+
+    profile = SimpleNamespace(contact_json={}, room_count=1)
+
+    async def _fetch_profile(_db, _shop_id):
+        return profile
+
+    monkeypatch.setattr(domain, "_try_fetch_profile", _fetch_profile)
+
+    async def _avail(_db, _therapist_id, _start_at, _end_at, lock=False):
+        return True, {"rejected_reasons": []}
+
+    monkeypatch.setattr(domain, "is_available", _avail)
+
+    expired_hold = GuestReservation(
+        shop_id=shop_id,
+        therapist_id=therapist_a,
+        start_at=start_at,
+        end_at=end_at,
+        duration_minutes=60,
+        planned_extension_minutes=0,
+        buffer_minutes=0,
+        status="reserved",
+        reserved_until=now - timedelta(minutes=10),
+    )
+
+    session = HoldSession([expired_hold])
+    reservation, debug, err = await create_guest_reservation_hold(
+        session,
+        {
+            "shop_id": shop_id,
+            "therapist_id": therapist_b,
+            "start_at": start_at,
+            "duration_minutes": 60,
+            "planned_extension_minutes": 0,
+        },
+        idempotency_key="k-ok",
+        now=now,
+    )
+    assert err is None
+    assert reservation is not None
+    assert debug == {}

--- a/osakamenesu/specs/availability/core.yaml
+++ b/osakamenesu/specs/availability/core.yaml
@@ -80,6 +80,7 @@ p1:
           default: 1
     rule: >
       shop_id 単位で、同一時間帯の “blocking statuses” の予約数が room_count を超えない。
+      超過する場合は rejected_reasons に room_full を含める。
     overlap_definition: >
       半開区間: start_at < other.end_at AND other.start_at < end_at
     indexes_plan:

--- a/osakamenesu/specs/reservations/core.yaml
+++ b/osakamenesu/specs/reservations/core.yaml
@@ -65,6 +65,7 @@ endpoints:
       - P0: end_at is derived server-side from (duration + planned_extension_minutes + after-buffer minutes). Client-provided end_at may be ignored for consistency.
       - P0: end_at is optional in request; provide one of (end_at, duration_minutes, course_id) to derive the timing.
       - P0: if profile.contact_json.booking_hours is configured, requests outside business hours should be rejected with reason outside_business_hours.
+      - P1: if shop capacity is exceeded (profile.room_count), requests should be rejected with reason room_full.
   - id: reservations.cancel
     method: POST
     path: /api/guest/reservations/{id}/cancel


### PR DESCRIPTION
## 目的
shop_id単位で同時間帯の「アクティブ予約数」が `room_count` を超えないようにし、create/hold の両方で同じ制約を効かせる（P1 Slice2b）。

## 変更概要
- DB: `profiles.room_count`（INT NOT NULL DEFAULT 1）を追加
- 予約作成/hold で shop_id の重複数をチェックし、超過時は `room_full` でreject
  - overlap判定: `start_at < other.end_at && other.start_at < end_at`（half-open）
  - block対象: `pending` / `confirmed` / `reserved(reserved_until > now)`
  - 非block: `cancelled` / `expired` / `no_show` / `draft`

## API挙動
- `rejected_reasons` に `room_full` を追加（既存のrejectedパターンに合わせる）

## 仕様（最小追記）
- `specs/reservations/core.yaml` / `specs/availability/core.yaml` に `room_full` を追記

## テスト
- `test_guest_reservations_room_count.py` で以下を固定
  - room_count=1: 別セラでも同時間帯は2件目NG
  - room_count=2: 2件目OK
  - reserved(未来reserved_until)はカウントする
  - reserved_until過去はカウントしない

pytest: 447 passed, 37 skipped

## 補足
- P1+（room_id/EXCLUDE等）は今回は未対応（最小差分）
