### PR TITLE
refactor(api): enforce SoT compliance for availability calculations

### DIFF
--- a/osakamenesu/services/api/app/domains/site/services/shop/availability.py
+++ b/osakamenesu/services/api/app/domains/site/services/shop/availability.py
@@ -143,40 +143,161 @@ async def fetch_next_available_slots(
     shop_ids: List[UUID],
     lookahead_days: int = 14,
 ) -> tuple[dict[UUID, NextAvailableSlot], dict[UUID, NextAvailableSlot]]:
+    """Fetch next available slots for shops using SoT (TherapistShift + GuestReservation).
+
+    SoT Compliance: Does NOT use slots_json. Calculates from TherapistShift directly.
+
+    Returns:
+        tuple[shop_map, staff_map] where:
+        - shop_map: {shop_id: NextAvailableSlot} - earliest slot per shop
+        - staff_map: {therapist_id: NextAvailableSlot} - earliest slot per therapist
+    """
     if not shop_ids:
         return {}, {}
+
     today = now_jst().date()
     end_date = today + timedelta(days=lookahead_days)
-    stmt = (
-        select(
-            models.Availability.profile_id,
-            models.Availability.slots_json,
-            models.Availability.date,
-        )
-        .where(models.Availability.profile_id.in_(shop_ids))
-        .where(models.Availability.date >= today)
-        .where(models.Availability.date <= end_date)
-        .order_by(models.Availability.profile_id.asc(), models.Availability.date.asc())
-    )
-    result = await db.execute(stmt)
-    rows = result.all()
     now_value = now_jst()
+
+    # 1) Get therapists for these shops
+    therapist_stmt = (
+        select(Therapist)
+        .where(Therapist.profile_id.in_(shop_ids))
+        .where(Therapist.status == "published")
+    )
+    therapist_res = await db.execute(therapist_stmt)
+    therapists = list(therapist_res.scalars().all())
+
+    if not therapists:
+        return {}, {}
+
+    therapist_ids = [t.id for t in therapists]
+    therapist_to_shop: dict[UUID, UUID] = {
+        t.id: t.profile_id for t in therapists if t.profile_id
+    }
+
+    # 2) Get shifts for these therapists (SoT)
+    shift_stmt = (
+        select(TherapistShift)
+        .where(TherapistShift.therapist_id.in_(therapist_ids))
+        .where(TherapistShift.availability_status == "available")
+        .where(TherapistShift.date >= today)
+        .where(TherapistShift.date <= end_date)
+        .order_by(TherapistShift.start_at.asc())
+    )
+    shift_res = await db.execute(shift_stmt)
+    shifts = list(shift_res.scalars().all())
+
+    # 3) Get active reservations for these therapists
+    from app.domains.site import therapist_availability as sot
+
+    range_start = datetime.combine(today, datetime.min.time()).replace(
+        tzinfo=now_value.tzinfo
+    )
+    range_end = datetime.combine(end_date, datetime.min.time()).replace(
+        tzinfo=now_value.tzinfo
+    ) + timedelta(days=1)
+
+    reservations_stmt = (
+        select(models.GuestReservation)
+        .where(models.GuestReservation.therapist_id.in_(therapist_ids))
+        .where(models.GuestReservation.status.in_(sot.ACTIVE_RESERVATION_STATUSES))
+        .where(models.GuestReservation.start_at < range_end)
+        .where(models.GuestReservation.end_at > range_start)
+    )
+    reservations = list((await db.execute(reservations_stmt)).scalars().all())
+    reservations = sot._filter_active_reservations(reservations, now_value)
+
+    # Group reservations by therapist
+    reservations_by_therapist: dict[UUID, list[models.GuestReservation]] = {}
+    for r in reservations:
+        if r.therapist_id not in reservations_by_therapist:
+            reservations_by_therapist[r.therapist_id] = []
+        reservations_by_therapist[r.therapist_id].append(r)
+
+    # 4) Get buffer_minutes per therapist
+    buffer_stmt = (
+        select(Therapist.id, models.Profile.buffer_minutes)
+        .join(models.Profile, models.Profile.id == Therapist.profile_id)
+        .where(Therapist.id.in_(therapist_ids))
+    )
+    buffer_rows = (await db.execute(buffer_stmt)).all()
+    buffer_by_therapist: dict[UUID, int] = {
+        tid: int(buf or 0) for tid, buf in buffer_rows
+    }
+
+    # 5) Calculate next available slot for each therapist using SoT logic
     shop_map: dict[UUID, tuple[datetime, NextAvailableSlot]] = {}
     staff_map: dict[UUID, tuple[datetime, NextAvailableSlot]] = {}
-    for profile_id, slots_json, _slot_date in rows:
-        slots = convert_slots(slots_json)
-        for slot in slots:
-            candidate = _build_next_slot_candidate(slot, now_jst_value=now_value)
-            if not candidate:
+
+    # Group shifts by therapist and date
+    shifts_by_therapist: dict[UUID, dict[date, list[TherapistShift]]] = {}
+    for shift in shifts:
+        if shift.therapist_id not in shifts_by_therapist:
+            shifts_by_therapist[shift.therapist_id] = {}
+        if shift.date not in shifts_by_therapist[shift.therapist_id]:
+            shifts_by_therapist[shift.therapist_id][shift.date] = []
+        shifts_by_therapist[shift.therapist_id][shift.date].append(shift)
+
+    for therapist_id in therapist_ids:
+        shop_id = therapist_to_shop.get(therapist_id)
+        if not shop_id:
+            continue
+
+        buffer_minutes = buffer_by_therapist.get(therapist_id, 0)
+        therapist_shifts = shifts_by_therapist.get(therapist_id, {})
+        therapist_reservations = reservations_by_therapist.get(therapist_id, [])
+
+        # Iterate through dates to find first available slot
+        current = today
+        found_slot = False
+        while current <= end_date and not found_slot:
+            day_shifts = therapist_shifts.get(current, [])
+            if not day_shifts:
+                current += timedelta(days=1)
                 continue
-            comparable, payload = candidate
-            existing_shop = shop_map.get(profile_id)
-            if existing_shop is None or comparable < existing_shop[0]:
-                shop_map[profile_id] = (comparable, payload)
-            if slot.staff_id:
-                existing_staff = staff_map.get(slot.staff_id)
-                if existing_staff is None or comparable < existing_staff[0]:
-                    staff_map[slot.staff_id] = (comparable, payload)
+
+            # Filter reservations for this day
+            day_start = datetime.combine(current, datetime.min.time()).replace(
+                tzinfo=now_value.tzinfo
+            )
+            day_end = day_start + timedelta(days=1)
+            day_reservations = [
+                r
+                for r in therapist_reservations
+                if r.start_at < day_end and r.end_at > day_start
+            ]
+
+            # Calculate available intervals using SoT logic
+            open_intervals = sot._calculate_available_slots(
+                day_shifts, day_reservations, buffer_minutes
+            )
+            filtered_intervals = sot._filter_slots_by_date(open_intervals, current)
+
+            if filtered_intervals:
+                slot_start, slot_end = filtered_intervals[0]
+                # Skip slots in the past
+                if slot_start > now_value:
+                    next_slot = NextAvailableSlot(
+                        start_at=slot_start,
+                        end_at=slot_end,
+                        status="ok",
+                    )
+
+                    # Update staff map (per therapist)
+                    existing_staff = staff_map.get(therapist_id)
+                    if existing_staff is None or slot_start < existing_staff[0]:
+                        staff_map[therapist_id] = (slot_start, next_slot)
+
+                    # Update shop map (earliest across all therapists)
+                    existing_shop = shop_map.get(shop_id)
+                    if existing_shop is None or slot_start < existing_shop[0]:
+                        shop_map[shop_id] = (slot_start, next_slot)
+
+                    found_slot = True
+
+            current += timedelta(days=1)
+
     return (
         {shop_id: data[1] for shop_id, data in shop_map.items()},
         {staff_id: data[1] for staff_id, data in staff_map.items()},
@@ -220,6 +341,8 @@ async def get_therapist_next_available_slots_by_shop(
     """
     店舗IDのリストから、その店舗に所属するセラピストの次回空き時間を取得する。
 
+    SoT Compliance: Uses TherapistShift + GuestReservation (not slots_json).
+
     Returns:
         dict[shop_id, dict[therapist_name, NextAvailableSlot]]
 
@@ -260,45 +383,117 @@ async def get_therapist_next_available_slots_by_shop(
     shift_res = await db.execute(shift_stmt)
     shifts = list(shift_res.scalars().all())
 
+    # Get active reservations for these therapists (SoT)
+    from app.domains.site import therapist_availability as sot
+
+    range_start = datetime.combine(today, datetime.min.time()).replace(
+        tzinfo=now_value.tzinfo
+    )
+    range_end = datetime.combine(end_date, datetime.min.time()).replace(
+        tzinfo=now_value.tzinfo
+    ) + timedelta(days=1)
+
+    reservations_stmt = (
+        select(models.GuestReservation)
+        .where(models.GuestReservation.therapist_id.in_(therapist_ids))
+        .where(models.GuestReservation.status.in_(sot.ACTIVE_RESERVATION_STATUSES))
+        .where(models.GuestReservation.start_at < range_end)
+        .where(models.GuestReservation.end_at > range_start)
+    )
+    reservations = list((await db.execute(reservations_stmt)).scalars().all())
+    reservations = sot._filter_active_reservations(reservations, now_value)
+
+    # Group reservations by therapist
+    reservations_by_therapist: dict[UUID, list[models.GuestReservation]] = {}
+    for r in reservations:
+        if r.therapist_id not in reservations_by_therapist:
+            reservations_by_therapist[r.therapist_id] = []
+        reservations_by_therapist[r.therapist_id].append(r)
+
+    # Get buffer_minutes per therapist
+    buffer_stmt = (
+        select(Therapist.id, models.Profile.buffer_minutes)
+        .join(models.Profile, models.Profile.id == Therapist.profile_id)
+        .where(Therapist.id.in_(therapist_ids))
+    )
+    buffer_rows = (await db.execute(buffer_stmt)).all()
+    buffer_by_therapist: dict[UUID, int] = {
+        tid: int(buf or 0) for tid, buf in buffer_rows
+    }
+
+    # Group shifts by therapist and date
+    shifts_by_therapist: dict[UUID, dict[date, list[TherapistShift]]] = {}
+    for shift in shifts:
+        if shift.therapist_id not in shifts_by_therapist:
+            shifts_by_therapist[shift.therapist_id] = {}
+        if shift.date not in shifts_by_therapist[shift.therapist_id]:
+            shifts_by_therapist[shift.therapist_id][shift.date] = []
+        shifts_by_therapist[shift.therapist_id][shift.date].append(shift)
+
     # 結果マップを構築
     result: dict[UUID, dict[str, NextAvailableSlot]] = {}
 
-    for shift in shifts:
-        therapist = therapist_map.get(shift.therapist_id)
-        if not therapist:
-            continue
-
+    for therapist_id, therapist in therapist_map.items():
         shop_id = therapist.profile_id
         if not shop_id:
             continue
-
-        # シフト開始時刻が現在より未来かチェック
-        shift_start = shift.start_at
-        if not isinstance(shift_start, datetime):
-            continue
-
-        comparable = ensure_jst_datetime(shift_start)
-        if comparable < now_value:
-            continue
-
-        # 店舗別・セラピスト名別にマップを構築
-        if shop_id not in result:
-            result[shop_id] = {}
 
         therapist_name = therapist.name
         if not therapist_name:
             continue
 
-        # 同じセラピストの中で最も早いスロットのみを保持
-        if therapist_name in result[shop_id]:
-            existing = result[shop_id][therapist_name]
-            if existing.start_at <= comparable:
+        buffer_minutes = buffer_by_therapist.get(therapist_id, 0)
+        therapist_shifts = shifts_by_therapist.get(therapist_id, {})
+        therapist_reservations = reservations_by_therapist.get(therapist_id, [])
+
+        # Iterate through dates to find first available slot
+        current = today
+        while current <= end_date:
+            day_shifts = therapist_shifts.get(current, [])
+            if not day_shifts:
+                current += timedelta(days=1)
                 continue
 
-        result[shop_id][therapist_name] = NextAvailableSlot(
-            start_at=comparable,
-            status="ok",
-        )
+            # Filter reservations for this day
+            day_start = datetime.combine(current, datetime.min.time()).replace(
+                tzinfo=now_value.tzinfo
+            )
+            day_end = day_start + timedelta(days=1)
+            day_reservations = [
+                r
+                for r in therapist_reservations
+                if r.start_at < day_end and r.end_at > day_start
+            ]
+
+            # Calculate available intervals using SoT logic
+            open_intervals = sot._calculate_available_slots(
+                day_shifts, day_reservations, buffer_minutes
+            )
+            filtered_intervals = sot._filter_slots_by_date(open_intervals, current)
+
+            for slot_start, slot_end in filtered_intervals:
+                # Skip slots in the past
+                if slot_start <= now_value:
+                    continue
+
+                # 店舗別・セラピスト名別にマップを構築
+                if shop_id not in result:
+                    result[shop_id] = {}
+
+                # 同じセラピストの中で最も早いスロットのみを保持
+                if therapist_name not in result[shop_id]:
+                    result[shop_id][therapist_name] = NextAvailableSlot(
+                        start_at=slot_start,
+                        end_at=slot_end,
+                        status="ok",
+                    )
+                break  # Found first available slot for this therapist
+
+            # If we found a slot for this therapist, move to next therapist
+            if shop_id in result and therapist_name in result[shop_id]:
+                break
+
+            current += timedelta(days=1)
 
     return result
 


### PR DESCRIPTION
## Summary
- Rewrite `fetch_next_available_slots()` and `get_therapist_next_available_slots_by_shop()` in `availability.py` to use TherapistShift + GuestReservation instead of slots_json
- Rewrite `_filter_results_by_availability()` in `search_service.py` to use SoT
- Remove dead fallback functions (`_fetch_availability_slots`, `_extract_slots_from_availability`, `_fetch_availability_slots_batch`) from `therapist_availability.py` that referenced slots_json
- Update tests to remove obsolete mocks

## Context
Per the Availability SoT specification (Issue #201):
- **Primary SoT**: `TherapistShift` + `GuestReservation`
- **Derived Cache**: `Availability.slots_json` (admin use only)
- Guest-facing code must NOT reference `slots_json`

## Files Changed
| File | Change |
|------|--------|
| `availability.py` | +207 lines (SoT implementation) |
| `search_service.py` | +50 lines (SoT filter) |
| `therapist_availability.py` | -64 lines (remove dead code) |
| `test_guest_therapist_availability.py` | -17 lines (remove obsolete mocks) |

## Test plan
- [x] All 447 unit tests pass
- [x] 43 availability-related tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, pytest)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)