### PR TITLE
feat(web): JST datetime handling and next_available_slot canonicalization

### DIFF
--- a/osakamenesu/apps/web/src/lib/availability.ts
+++ b/osakamenesu/apps/web/src/lib/availability.ts
@@ -8,7 +8,39 @@
  * Use today(), extractDate(), extractTime(), isToday(), isSameDate() from there.
  */
 
-import { today as jstToday, extractDate, extractTime, isToday, isSameDate } from '@/lib/jst'
+import {
+  today as jstToday,
+  extractDate,
+  extractTime,
+  isToday as jstIsToday,
+  isSameDate,
+  formatDateISO,
+} from '@/lib/jst'
+
+// =============================================================================
+// Deprecated re-exports for backward compatibility (used by tests)
+// Use lib/jst.ts directly in new code
+// =============================================================================
+
+/** @deprecated Use today() from lib/jst.ts */
+export const getTodayIsoString = jstToday
+
+/** @deprecated Use extractDate() from lib/jst.ts */
+export const extractDateFromIso = extractDate
+
+/** @deprecated Use isSameDate() from lib/jst.ts */
+export const isSameDayIso = isSameDate
+
+/** @deprecated Use isToday() from lib/jst.ts */
+export const isTodayIso = jstIsToday
+
+/** @deprecated Use isSameDate(formatDateISO(d1), formatDateISO(d2)) from lib/jst.ts */
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return isSameDate(formatDateISO(date1), formatDateISO(date2))
+}
+
+/** @deprecated Use extractTime() from lib/jst.ts */
+export const extractTimeKey = extractTime
 
 // =============================================================================
 // 型定義


### PR DESCRIPTION
## Summary
- Add deprecated re-exports in `availability.ts` for backward compatibility with tests
- These wrappers point to the canonical JST utilities in `lib/jst.ts`

## Context
This is a follow-up to #226 and #227, maintaining backward compatibility while transitioning to the new JST utilities.

## Test plan
- [x] Existing tests continue to work with deprecated re-exports
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)