### PR TITLE
feat(web): unify availability icons and disable blocked cells (Phase 2)

### DIFF
--- a/osakamenesu/apps/web/src/components/calendar/WeekAvailabilityGrid.tsx
+++ b/osakamenesu/apps/web/src/components/calendar/WeekAvailabilityGrid.tsx
@@ -276,7 +276,10 @@ export function WeekAvailabilityGrid({
                     data-date={day.date}
                     data-start-minutes={blockedStartMinutes}
                     data-start-at={slot?.start_at}
-                    className="flex h-14 items-center justify-center border-b border-white/65 bg-white/70"
+                    className="flex h-14 cursor-not-allowed items-center justify-center border-b border-white/65 bg-white/70 opacity-60 pointer-events-none"
+                    role="gridcell"
+                    aria-disabled="true"
+                    tabIndex={-1}
                   >
                     <span className={buildUnavailableClass(selectedNow)} aria-hidden>
                       ×
@@ -314,7 +317,7 @@ export function WeekAvailabilityGrid({
                   aria-label={`${day.label} ${timeFormatter.format(new Date(slot!.start_at))} ${statusMeta.icon} ${statusMeta.label}`}
                 >
                   <span className={iconClass} aria-hidden>
-                    {slot!.status === 'open' ? '●' : statusMeta.icon}
+                    {statusMeta.icon}
                   </span>
                 </button>
               )


### PR DESCRIPTION
## Summary
- Change open status icon from ● to ◎ (using AVAILABILITY_STATUS_META consistently)
- Add disabled state for blocked cells with proper CSS and accessibility attributes
- Implements Phase 2.1 and 2.2 of availability-calendar-ui spec

## Changes
- `apps/web/src/components/calendar/WeekAvailabilityGrid.tsx`:
  - Use `statusMeta.icon` for all status types instead of hardcoded `●` for open
  - Add `pointer-events: none`, `cursor: not-allowed`, `opacity: 0.6` to blocked cells
  - Add `role="gridcell"`, `aria-disabled="true"`, `tabIndex={-1}` for accessibility

## Test plan
- [ ] Verify open slots display ◎ icon instead of ●
- [ ] Verify blocked cells are visually dimmed (opacity: 0.6)
- [ ] Verify blocked cells cannot be clicked
- [ ] Verify keyboard navigation skips blocked cells
- [ ] Run `pnpm test:unit` - all 179 tests pass
- [ ] Run `pnpm typecheck` - no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)