### PR TITLE
feat(web): add real-time slot verification before reservation (Phase 3)

### DIFF
--- a/osakamenesu/apps/web/src/components/ReservationForm.tsx
+++ b/osakamenesu/apps/web/src/components/ReservationForm.tsx
@@ -5,6 +5,7 @@ import ReservationPersonalInfoFields from './reservation/ReservationPersonalInfo
 import ReservationCourseSelector from './reservation/ReservationCourseSelector'
 import ReservationNotesPreferences from './reservation/ReservationNotesPreferences'
 import ReservationSubmissionDetails from './reservation/ReservationSubmissionDetails'
+import { ConflictErrorBanner } from './reservation/ConflictErrorBanner'
 import {
   useReservationForm,
   type UseReservationFormProps,
@@ -33,12 +34,15 @@ export default function ReservationForm(props: ReservationFormProps) {
     lastPayload,
     summaryText,
     isPending,
+    isVerifying,
     canSubmit,
     disabled,
     minutesOptions,
     toasts,
     removeToast,
     hasContactChannels,
+    conflictError,
+    dismissConflictError,
     actions: { handleChange, toggleRemember, handleCourseSelect, submit, copySummary },
   } = useReservationForm(hookProps)
 
@@ -53,6 +57,8 @@ export default function ReservationForm(props: ReservationFormProps) {
 
   return (
     <div className="space-y-5">
+      <ConflictErrorBanner error={conflictError} onDismiss={dismissConflictError} />
+
       <ReservationSelectedSlotsNotice slots={props.selectedSlots} />
 
       {errors.desiredStart ? (
@@ -128,7 +134,15 @@ export default function ReservationForm(props: ReservationFormProps) {
           {/* Animated background shine */}
           <div className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/20 to-transparent transition-transform duration-700 group-hover:translate-x-full" />
 
-          {isPending ? (
+          {isVerifying ? (
+            <>
+              <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+              <span>空き状況を確認中...</span>
+            </>
+          ) : isPending ? (
             <>
               <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />

--- a/osakamenesu/apps/web/src/components/reservation/ConflictErrorBanner.tsx
+++ b/osakamenesu/apps/web/src/components/reservation/ConflictErrorBanner.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export type ConflictError = {
+  message: string
+  slotStart: string
+  showUntil: number // Unix timestamp in ms
+}
+
+type ConflictErrorBannerProps = {
+  error: ConflictError | null
+  onDismiss: () => void
+}
+
+/**
+ * Banner component that displays slot conflict errors.
+ * Auto-dismisses after the showUntil time is reached.
+ */
+export function ConflictErrorBanner({ error, onDismiss }: ConflictErrorBannerProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!error) {
+      setVisible(false)
+      return
+    }
+
+    // Show the banner
+    setVisible(true)
+
+    // Calculate remaining time until auto-dismiss
+    const now = Date.now()
+    const remaining = error.showUntil - now
+
+    if (remaining <= 0) {
+      setVisible(false)
+      onDismiss()
+      return
+    }
+
+    // Set up auto-dismiss timer
+    const timer = setTimeout(() => {
+      setVisible(false)
+      onDismiss()
+    }, remaining)
+
+    return () => clearTimeout(timer)
+  }, [error, onDismiss])
+
+  if (!visible || !error) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="animate-in slide-in-from-top-2 fade-in flex items-start gap-3 rounded-2xl border border-red-200 bg-gradient-to-r from-red-50 to-red-50/80 px-4 py-3 shadow-lg duration-300"
+    >
+      <div className="flex-shrink-0 pt-0.5">
+        <svg
+          className="h-5 w-5 text-red-500"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-red-800">{error.message}</p>
+        <p className="mt-1 text-xs text-red-600/80">
+          カレンダーを更新しました。別の時間をお選びください。
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="flex-shrink-0 rounded-lg p-1 text-red-400 hover:bg-red-100 hover:text-red-600 transition-colors"
+        aria-label="閉じる"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/osakamenesu/apps/web/src/lib/verify-slot.ts
+++ b/osakamenesu/apps/web/src/lib/verify-slot.ts
@@ -1,0 +1,93 @@
+'use client'
+
+/**
+ * Slot verification API client
+ *
+ * Calls the verify_slot endpoint to check if a slot is still available
+ * before submitting a reservation.
+ */
+
+export type SlotVerificationResult =
+  | {
+      isAvailable: true
+      status: 'open'
+      verifiedAt: string
+    }
+  | {
+      isAvailable: false
+      status: 'blocked' | 'tentative'
+      conflictedAt: string
+      reason?: string
+    }
+
+export type SlotConflictError = {
+  message: string
+  slotStart: string
+  currentStatus: string
+  conflictedAt: string
+}
+
+/**
+ * Verify if a slot is still available for booking.
+ *
+ * @param therapistId - The therapist UUID
+ * @param startAt - The slot start time in ISO format
+ * @returns Verification result indicating availability
+ */
+export async function verifySlot(
+  therapistId: string,
+  startAt: string,
+): Promise<SlotVerificationResult> {
+  const params = new URLSearchParams({ start_at: startAt })
+  const url = `/api/guest/therapists/${therapistId}/verify_slot?${params.toString()}`
+
+  const resp = await fetch(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  })
+
+  if (resp.ok) {
+    const data = await resp.json()
+    return {
+      isAvailable: data.is_available ?? true,
+      status: data.status ?? 'open',
+      verifiedAt: data.verified_at ?? new Date().toISOString(),
+    }
+  }
+
+  if (resp.status === 409) {
+    const data = await resp.json()
+    const detail = data.detail ?? {}
+    return {
+      isAvailable: false,
+      status: detail.status ?? 'blocked',
+      conflictedAt: detail.conflicted_at ?? new Date().toISOString(),
+      reason: detail.reason ?? 'already_reserved',
+    }
+  }
+
+  // For other errors, treat as unavailable
+  return {
+    isAvailable: false,
+    status: 'blocked',
+    conflictedAt: new Date().toISOString(),
+    reason: 'verification_failed',
+  }
+}
+
+/**
+ * Create a user-friendly error message for slot conflicts.
+ */
+export function createConflictErrorMessage(reason?: string): string {
+  switch (reason) {
+    case 'already_reserved':
+      return '申し訳ございません。選択された時間は他のお客様により予約されました。別の時間をお選びください。'
+    case 'past_slot':
+      return '選択された時間は既に過ぎています。別の時間をお選びください。'
+    case 'verification_failed':
+      return '空き状況の確認に失敗しました。ページを更新して再度お試しください。'
+    default:
+      return '選択された時間は予約できません。別の時間をお選びください。'
+  }
+}


### PR DESCRIPTION
## Summary
- Add real-time slot verification before reservation submission
- Implement conflict error handling with 3-second auto-dismiss banner
- Implements Phase 3 of availability-calendar-ui spec

## Changes

### New files
- `apps/web/src/lib/verify-slot.ts`
  - `verifySlot()` function to call `/verify_slot` API
  - `createConflictErrorMessage()` for user-friendly error messages
  - Type definitions for verification results

- `apps/web/src/components/reservation/ConflictErrorBanner.tsx`
  - Error banner with auto-dismiss after 3 seconds
  - ARIA attributes for accessibility (`role="alert"`, `aria-live="assertive"`)
  - Manual dismiss button

### Modified files
- `apps/web/src/components/reservation/useReservationForm.ts`
  - Added `isVerifying` state for loading indicator
  - Added `conflictError` state for error display
  - Call `verifySlot()` before reservation submission
  - Handle 409 Conflict by showing error and triggering calendar refresh

- `apps/web/src/components/ReservationForm.tsx`
  - Added ConflictErrorBanner component
  - Show "空き状況を確認中..." during verification

## Flow
1. User clicks "予約リクエストを送信"
2. `verifySlot()` API called with therapist ID and slot start time
3. If slot available (200): proceed to reservation submission
4. If conflict (409): show error banner, refresh calendar, clear selection

## Test plan
- [ ] Verify "空き状況を確認中..." shows during verification
- [ ] Verify conflict error banner appears when slot is unavailable
- [ ] Verify banner auto-dismisses after 3 seconds
- [ ] Verify manual dismiss works
- [ ] Run `pnpm test:unit` - all 179 tests pass

## Dependencies
- Requires PR #230 (verify_slot API endpoint) to be merged first

🤖 Generated with [Claude Code](https://claude.com/claude-code)