### PR TITLE
refactor(web): remove tentative legacy fallback

### DIFF
--- a/osakamenesu/apps/web/src/lib/availability.ts
+++ b/osakamenesu/apps/web/src/lib/availability.ts
@@ -82,9 +82,6 @@ export type DisplayAvailabilityDay = Omit<NormalizedAvailabilityDay, 'is_today' 
  * - available/ok → open (DB語彙のマッピング)
  * - busy/unavailable → blocked (DB語彙のマッピング)
  * - tentative は API から返されない（UI-only state）
- *
- * Note: 既存の tentative/maybe 処理は後方互換性のために残すが、
- * 新しいAPIでは使用されない
  */
 export function normalizeSlotStatus(rawStatus?: string | null): AvailabilityStatus {
   const status = (rawStatus ?? 'open').toLowerCase()
@@ -92,9 +89,7 @@ export function normalizeSlotStatus(rawStatus?: string | null): AvailabilityStat
   if (status === 'open' || status === 'available' || status === 'ok') return 'open'
   // Final Decision: DB "busy" → API "blocked"
   if (status === 'blocked' || status === 'busy' || status === 'unavailable') return 'blocked'
-  // Legacy fallback (tentative is UI-only, should not come from API)
-  if (status === 'tentative' || status === 'maybe') return 'tentative'
-  return 'open' // デフォルト
+  return 'open' // デフォルト（未知のステータスは open として扱う）
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Remove tentative/maybe legacy fallback from `normalizeSlotStatus` in availability.ts
- Final Decision confirmed: `tentative` is UI-only state, not returned from API
- Unknown statuses (including tentative/maybe from legacy data) now default to `'open'`

## Changes
- `availability.ts`: Removed legacy fallback code for tentative/maybe
- `availability.test.ts`: Updated tests to reflect new behavior

## Test plan
- [x] Run availability.ts unit tests (49 tests passed)
- [x] Run API timezone tests (3 tests passed)
- [x] TypeScript typecheck passed
- [x] ESLint passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)