### PR TITLE
feat(admin): add confirmation dialogs and validation to edit pages

### DIFF
--- a/osakamenesu/apps/web/src/components/ui/ConfirmDialog.tsx
+++ b/osakamenesu/apps/web/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+type ConfirmDialogProps = {
+  open: boolean
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'default' | 'danger'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = '確認',
+  cancelLabel = 'キャンセル',
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (open) {
+      dialog.showModal()
+    } else {
+      dialog.close()
+    }
+  }, [open])
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) {
+        onCancel()
+      }
+    },
+    [onCancel]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel()
+      }
+    },
+    [onCancel]
+  )
+
+  if (!open) return null
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="fixed inset-0 z-50 m-auto rounded-lg border border-neutral-borderLight bg-white p-0 shadow-xl backdrop:bg-black/50"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="min-w-[300px] max-w-md p-4">
+        <h2 className="mb-2 text-lg font-semibold text-neutral-text">{title}</h2>
+        <p className="mb-4 text-sm text-neutral-textMuted">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-neutral-borderLight bg-white px-4 py-2 text-sm hover:bg-neutral-50"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`rounded px-4 py-2 text-sm text-white ${
+              variant === 'danger'
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-brand-primary hover:brightness-110'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  )
+}


### PR DESCRIPTION
## Summary

- Create reusable `ConfirmDialog` component using HTML5 `<dialog>` element
- Add status change confirmation for therapist edit page (active ↔ draft)
- Add status change confirmation for shop edit page (published ↔ draft)
- Add client-side form validation with error messages for both edit pages

## Changes

### ConfirmDialog Component (`apps/web/src/components/ui/ConfirmDialog.tsx`)
- Reusable modal dialog with title, message, and confirm/cancel buttons
- Supports `variant` prop for 'default' or 'danger' styling
- Handles backdrop click and Escape key to cancel

### Therapist Edit Page
- Confirmation dialog when changing status to/from 'active'
- Validation rules:
  - Name: required, max 50 characters
  - Age: 18-99 range
  - Headline: max 100 characters
  - Biography: max 1000 characters
  - Photo URLs: valid URL format

### Shop Edit Page
- Confirmation dialog when changing status to/from 'published'
- Validation rules:
  - Name: required, max 100 characters
  - Slug: alphanumeric and hyphens only
  - Catch copy: max 100 characters
  - Description: max 2000 characters
  - Buffer minutes: 0-120 range
  - Room count: min 1
  - Default slot duration: min 30 minutes
  - Price range: min <= max
  - Photo URLs: valid URL format
  - Website URL: valid URL format

## Test Plan

- [ ] Verify therapist edit page shows confirmation when toggling active status
- [ ] Verify shop edit page shows confirmation when toggling published status
- [ ] Verify validation errors display correctly for invalid inputs
- [ ] Verify form submission is blocked when validation fails

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)