### PR TITLE
docs: add SITE_BASE_URL config for magic link email

### DIFF
--- a/osakamenesu/.env.example
+++ b/osakamenesu/.env.example
@@ -39,6 +39,10 @@ API_INTERNAL_BASE=http://osakamenesu-api:8000
 # NOTIFY_EMAIL_ENDPOINT=https://your-email-service.com/send
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/xxx/xxx
 
+# === Magic Link Auth ===
+# Required for email-based login to work
+# SITE_BASE_URL=https://yourdomain.com
+
 # === Admin Dashboard Auth ===
 ADMIN_BASIC_USER=yusaku0324
 ADMIN_BASIC_PASS=sakanon0402


### PR DESCRIPTION
## Summary

Documents the environment configuration needed for magic link email authentication.

The magic link email functionality was **already fully implemented** - it just needed proper environment variable configuration.

## What Was Already Implemented

- Token generation with secure hashing
- Rate limiting (5 requests per 10 minutes)
- Resend email integration
- HTML and plain text email templates (Japanese)
- Token verification and session creation
- Debug logging mode for development

## Configuration Required

Add to `.env` for production:
```bash
MAIL_APIKEY=re_xxxxxxxxxxxx
MAIL_FROM_ADDRESS=no-reply@osakamenesu.com
SITE_BASE_URL=https://osakamenesu.com
```

## How It Works

1. User requests magic link at `/api/auth/request-link`
2. System generates secure token, stores hash in DB
3. Email sent via Resend with link to `/auth/complete?token=xxx`
4. User clicks link, token verified, session created
5. Session cookie set for 30 days

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)